### PR TITLE
Use bash for setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit -o errtrace -o pipefail
 trap 'echo "Error on line ${LINENO}"' ERR


### PR DESCRIPTION
`-o errtrace` is not a valid option for sh but is for bash
