### PR TITLE
Add unique test database names to prevent conflicts

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,4 +1,4 @@
-1.0.0
+STABLE
 -----
 == Use unique database names for tests
 Tests now use a unique database name based on the project name and a hash of the current directory. This prevents test conflicts when running tests for multiple projects in parallel.
@@ -6,6 +6,8 @@ Tests now use a unique database name based on the project name and a hash of the
 == Add 3-way merge support for setup files after pgxntool-sync
 New `update-setup-files.sh` script handles merging changes to files initially copied by `setup.sh` (`.gitignore`, `test/deps.sql`). After running `make pgxntool-sync`, the script performs a 3-way merge if both you and pgxntool have modified the same file, using git's native conflict markers for resolution.
 
+1.0.0
+-----
 == Fix broken multi-extension support
 Prior to this fix, distributions with multiple extensions or extensions with versions different from the PGXN distribution version were completely broken. Extension versions are now correctly read from each `.control` file's `default_version` instead of using META.json's distribution version.
 

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,5 +1,11 @@
 1.0.0
 -----
+== Use unique database names for tests
+Tests now use a unique database name based on the project name and a hash of the current directory. This prevents test conflicts when running tests for multiple projects in parallel.
+
+== Add 3-way merge support for setup files after pgxntool-sync
+New `update-setup-files.sh` script handles merging changes to files initially copied by `setup.sh` (`.gitignore`, `test/deps.sql`). After running `make pgxntool-sync`, the script performs a 3-way merge if both you and pgxntool have modified the same file, using git's native conflict markers for resolution.
+
 == Fix broken multi-extension support
 Prior to this fix, distributions with multiple extensions or extensions with versions different from the PGXN distribution version were completely broken. Extension versions are now correctly read from each `.control` file's `default_version` instead of using META.json's distribution version.
 

--- a/base.mk
+++ b/base.mk
@@ -313,8 +313,10 @@ pgxntool-sync: pgxntool-sync-release
 # could make resolving merges difficult!
 pgxntool-sync-release	:= git@github.com:decibel/pgxntool.git release
 pgxntool-sync-stable	:= git@github.com:decibel/pgxntool.git stable
+pgxntool-sync-master	:= git@github.com:decibel/pgxntool.git master
 pgxntool-sync-local		:= ../pgxntool release # Not the same as PGXNTOOL_DIR!
 pgxntool-sync-local-stable	:= ../pgxntool stable # Not the same as PGXNTOOL_DIR!
+pgxntool-sync-local-master	:= ../pgxntool master # Not the same as PGXNTOOL_DIR!
 
 distclean:
 	rm -f $(PGXNTOOL_distclean)

--- a/base.mk
+++ b/base.mk
@@ -64,6 +64,13 @@ TEST__SOURCE__SQL_FILES	 = $(patsubst $(TESTDIR)/input/%.source,$(TESTDIR)/sql/%
 TEST__SOURCE__EXPECTED_FILES = $(patsubst $(TESTDIR)/output/%.source,$(TESTDIR)/expected/%.out,$(TEST__SOURCE__OUTPUT_FILES))
 REGRESS		 = $(sort $(notdir $(subst .source,,$(TEST_FILES:.sql=)))) # Sort is to get unique list
 REGRESS_OPTS = --inputdir=$(TESTDIR) --outputdir=$(TESTOUT) # See additional setup below
+
+# Generate unique database name for tests to prevent conflicts across projects
+# Uses project name + first 5 chars of md5 hash of current directory
+# This prevents multiple test runs in different directories from clobbering each other
+REGRESS_DBHASH := $(shell echo $(CURDIR) | (md5 2>/dev/null || md5sum) | cut -c1-5)
+REGRESS_DBNAME := $(or $(PGXN),regression)_$(REGRESS_DBHASH)
+REGRESS_OPTS += --dbname=$(REGRESS_DBNAME)
 MODULES      = $(patsubst %.c,%,$(wildcard src/*.c))
 ifeq ($(strip $(MODULES)),)
 MODULES =# Set to NUL so PGXS doesn't puke


### PR DESCRIPTION
Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/4

## Summary

Tests now use unique database names based on project name + hash of directory path. This prevents test conflicts when running tests for multiple projects in parallel.

Cross-platform: uses `md5` on macOS, `md5sum` on Linux.

Also adds `pgxntool-sync-master` and `pgxntool-sync-local-master` targets, and updates HISTORY.asc.

Changes only in pgxntool. No related changes in pgxntool-test.

🤖 Generated with [Claude Code](https://claude.ai/code)