### PR TITLE
Fix pg_tle exception handler and empty upgrade files

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,11 @@
+STABLE
+------
+== Fix pg_tle exception handler and empty upgrade files
+The exception handler for `uninstall_extension()` now correctly catches
+`no_data_found` (P0002) instead of `undefined_object` (42704). Empty upgrade
+files are now treated as valid no-op upgrades for version bumps. Added
+`ON_ERROR_STOP=1` to `run_pgtle_sql()` so psql errors propagate correctly.
+
 1.1.0
 -----
 == Use unique database names for tests

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -9,18 +9,28 @@ files are now treated as valid no-op upgrades for version bumps. Added
 1.1.0
 -----
 == Use unique database names for tests
-Tests now use a unique database name based on the project name and a hash of the current directory. This prevents test conflicts when running tests for multiple projects in parallel.
+Tests now use a unique database name based on the project name and a hash of the
+current directory. This prevents test conflicts when running tests for multiple
+projects in parallel.
 
 == Add 3-way merge support for setup files after pgxntool-sync
-New `update-setup-files.sh` script handles merging changes to files initially copied by `setup.sh` (`.gitignore`, `test/deps.sql`). After running `make pgxntool-sync`, the script performs a 3-way merge if both you and pgxntool have modified the same file, using git's native conflict markers for resolution.
+New `update-setup-files.sh` script handles merging changes to files initially
+copied by `setup.sh` (`.gitignore`, `test/deps.sql`). After running `make
+pgxntool-sync`, the script performs a 3-way merge if both you and pgxntool have
+modified the same file, using git's native conflict markers for resolution.
 
 1.0.0
 -----
 == Fix broken multi-extension support
-Prior to this fix, distributions with multiple extensions or extensions with versions different from the PGXN distribution version were completely broken. Extension versions are now correctly read from each `.control` file's `default_version` instead of using META.json's distribution version.
+Prior to this fix, distributions with multiple extensions or extensions with
+versions different from the PGXN distribution version were completely broken.
+Extension versions are now correctly read from each `.control` file's
+`default_version` instead of using META.json's distribution version.
 
 == Add pg_tle support
-New `make pgtle` target generates pg_tle registration SQL for extensions. Supports pg_tle version ranges (1.0.0-1.4.0, 1.4.0-1.5.0, 1.5.0+) with appropriate API calls for each range. See README for usage.
+New `make pgtle` target generates pg_tle registration SQL for extensions.
+Supports pg_tle version ranges (1.0.0-1.4.0, 1.4.0-1.5.0, 1.5.0+) with
+appropriate API calls for each range. See README for usage.
 
 == Use git tags for distribution versioning
 The `tag` and `rmtag` targets now create/delete git tags instead of branches.
@@ -32,7 +42,9 @@ The `--load-language` option was removed from `pg_regress` in 13.
 As part of this change, you will want to review the changes to test/deps.sql.
 
 === Support asciidoc documentation targets
-By default, if asciidoctor or asciidoc exists on the system, any files in doc/ that end in .adoc or .asciidoc will be processed to html.
+By default, if asciidoctor or asciidoc exists on the system, any files in doc/
+that end in .adoc or .asciidoc will be processed to html.
+
 See the README for full details.
 
 === Support 9.2

--- a/base.mk
+++ b/base.mk
@@ -304,8 +304,8 @@ print-%	: ; $(info $* is $(flavor $*) variable set to "$($*)") @true
 # 3-way merge if both you and pgxntool changed the file.
 .PHONY: pgxntool-sync-%
 pgxntool-sync-%:
-	@old_commit=$$(git log -1 --format=%H -- pgxntool/); \
-	git subtree pull -P pgxntool --squash -m "Pull pgxntool from $($@)" $($@); \
+	@old_commit=$$(git log -1 --format=%H -- pgxntool/) && \
+	git subtree pull -P pgxntool --squash -m "Pull pgxntool from $($@)" $($@) && \
 	pgxntool/update-setup-files.sh "$$old_commit"
 pgxntool-sync: pgxntool-sync-release
 

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -661,17 +661,17 @@ generate_header() {
  *   - Upgrade paths: ${upgrade_count} path(s)
  *   - Default version: ${DEFAULT_VERSION}
  *
- * Installation instructions:
- *   1. Ensure pg_tle is installed:
- *      CREATE EXTENSION pg_tle;
+ * Installation:
+ *   Recommended: make run-pgtle
+ *   (or: pgxntool/pgtle.sh --run)
  *
- *   2. Ensure you have pgtle_admin role:
- *      GRANT pgtle_admin TO your_username;
+ *   This automatically detects your pg_tle version and runs the correct file.
  *
- *   3. Run this file:
- *      psql -f $(basename "$output_file")
+ *   Prerequisites:
+ *   - pg_tle extension installed (CREATE EXTENSION pg_tle;)
+ *   - pgtle_admin role (GRANT pgtle_admin TO your_username;)
  *
- *   4. Create the extension:
+ *   After registration, create the extension:
  *      CREATE EXTENSION ${EXTENSION};
  *
  * Version compatibility:

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -330,7 +330,7 @@ run_pgtle_sql() {
         if [ -f "$sql_file" ]; then
             found=1
             echo "Running $sql_file..." >&2
-            psql --no-psqlrc --file="$sql_file" || exit 1
+            psql --no-psqlrc -v ON_ERROR_STOP=1 --file="$sql_file" || exit 1
         fi
     done
     
@@ -545,10 +545,7 @@ discover_sql_files() {
     UPGRADE_FILES=()  # Reset array
     debug 30 "discover_sql_files: Reset UPGRADE_FILES array"
     while IFS= read -r -d '' file; do
-        # Error on empty upgrade files
-        if [ ! -s "$file" ]; then
-            die 1 "Empty upgrade file found: $file"
-        fi
+        # Empty upgrade files are allowed (no-op upgrades)
         local basename=$(basename "$file" .sql)
         local dash_count=$(echo "$basename" | grep -o -- "--" | wc -l | tr -d '[:space:]')
         if [ "$dash_count" -eq 2 ]; then
@@ -615,6 +612,7 @@ wrap_sql_content() {
     validate_delimiter "$sql_file"
 
     # Output wrapped SQL with proper indentation
+    # Empty files are valid (no-op upgrades)
     echo "  ${PGTLE_DELIMITER}"
     cat "$sql_file"
     echo "  ${PGTLE_DELIMITER}"
@@ -799,8 +797,8 @@ DO \$\$
 BEGIN
     PERFORM pgtle.uninstall_extension('${EXTENSION}');
 EXCEPTION
-    WHEN undefined_object THEN
-        -- Extension might not exist yet
+    WHEN no_data_found THEN
+        -- Extension not registered yet (pg_tle raises P0002, not 42704)
         NULL;
 END
 \$\$;


### PR DESCRIPTION
Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/5

## Summary

- Fix exception handler to use `no_data_found` (P0002) instead of `undefined_object` (42704) — pg_tle's `uninstall_extension()` raises P0002 when extension is not registered
- Allow empty upgrade files as valid no-op upgrades for version bumps
- Add `ON_ERROR_STOP=1` to `run_pgtle_sql()` so psql errors propagate correctly

## Details

**Exception handler fix:** The generated SQL's exception handler was catching the wrong SQLSTATE. pg_tle raises `no_data_found` (P0002) when `uninstall_extension()` is called on a non-existent extension, not `undefined_object` (42704). This caused the handler to fail silently.

**Empty upgrade files:** Empty upgrade files (e.g., `extension--1.0--1.1.sql` with no content) are legitimate no-op upgrades for version bumps. The script was previously rejecting them with an error.

**Error propagation:** `run_pgtle_sql()` now uses `psql -v ON_ERROR_STOP=1` so that SQL errors cause the script to exit with failure instead of continuing after a rolled-back transaction.

🤖 Generated with [Claude Code](https://claude.ai/code)