### PR TITLE
Fix bash 3.2 compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Scope of This File
+
+The guidance in this CLAUDE.md applies to pgxntool's own source files and provides
+recommended best practices for projects using pgxntool. However, any agent working in
+an extension project should always defer to that project's own CLAUDE.md and
+instructions over anything stated here.
+
 ## Git Commit Guidelines
 
 **IMPORTANT**: When creating commit messages, do not attribute commits to yourself (Claude). Commit messages should reflect the work being done without AI attribution in the message body. The standard Co-Authored-By trailer is acceptable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,12 @@ Generated files depend on:
 5. **PGXNTOOL_NO_PGXS_INCLUDE**: Setting this skips PGXS inclusion (for special scenarios)
 6. **Distribution Placement**: `.zip` files go in parent directory (`../`) to avoid repo clutter
 
+## Shell Script Standards
+
+**RULE**: Always use `#!/usr/bin/env bash`, never `#!/bin/bash`.
+
+`/bin/bash` hardcodes the path and fails on systems where bash is elsewhere (some BSDs, NixOS, Homebrew on macOS). `#!/usr/bin/env bash` finds bash on `PATH` and works everywhere.
+
 ## Scripts
 
 - **setup.sh** - Initializes pgxntool in a new extension project (copies templates, creates directories)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,12 +241,6 @@ Generated files depend on:
 5. **PGXNTOOL_NO_PGXS_INCLUDE**: Setting this skips PGXS inclusion (for special scenarios)
 6. **Distribution Placement**: `.zip` files go in parent directory (`../`) to avoid repo clutter
 
-## Shell Script Standards
-
-**RULE**: Always use `#!/usr/bin/env bash`, never `#!/bin/bash`.
-
-`/bin/bash` hardcodes the path and fails on systems where bash is elsewhere (some BSDs, NixOS, Homebrew on macOS). `#!/usr/bin/env bash` finds bash on `PATH` and works everywhere.
-
 ## Scripts
 
 - **setup.sh** - Initializes pgxntool in a new extension project (copies templates, creates directories)

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -9,12 +9,9 @@ the special-case logic in `make results` have been removed. Extensions
 that used `.source` files should convert them to regular `test/sql/*.sql`
 and `test/expected/*.out` files using relative paths.
 
-== Fix bash 3.2 compatibility
-`pgtle.sh` used `${#ARRAY[@]:-0}` which is a syntax error in bash 3.2
-("bad substitution"). Changed to `${#ARRAY[@]}`, which correctly returns
-0 for empty arrays in all bash versions. `base.mk` now deduplicates `DOCS`
-when adding generated HTML to prevent duplicate install entries when HTML
-files are already included by wildcard.
+== Fix bash 3.2 compatibility and shebang portability
+`${#ARRAY[@]:-0}` is a syntax error in bash 3.2; replaced with `${#ARRAY[@]}`.
+Shell scripts now use `#!/usr/bin/env bash`.
 
 1.1.2
 -----

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,12 +1,5 @@
 STABLE
 ------
-== Fix bash 3.2 compatibility
-`pgtle.sh` used `${#ARRAY[@]:-0}` which is a syntax error in bash 3.2
-("bad substitution"). Changed to `${#ARRAY[@]}`, which correctly returns
-0 for empty arrays in all bash versions. `base.mk` now deduplicates `DOCS`
-when adding generated HTML to prevent duplicate install entries when HTML
-files are already included by wildcard.
-
 == Remove .source file support
 PostgreSQL removed `.source` file processing from `pg_regress` in PG15.
 The `input/*.source` → `sql/*.sql` and `output/*.source` →
@@ -15,6 +8,13 @@ variables (`TEST__SOURCE__*`), the `make_results.sh` helper script, and
 the special-case logic in `make results` have been removed. Extensions
 that used `.source` files should convert them to regular `test/sql/*.sql`
 and `test/expected/*.out` files using relative paths.
+
+== Fix bash 3.2 compatibility
+`pgtle.sh` used `${#ARRAY[@]:-0}` which is a syntax error in bash 3.2
+("bad substitution"). Changed to `${#ARRAY[@]}`, which correctly returns
+0 for empty arrays in all bash versions. `base.mk` now deduplicates `DOCS`
+when adding generated HTML to prevent duplicate install entries when HTML
+files are already included by wildcard.
 
 1.1.2
 -----

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,5 +1,12 @@
 STABLE
 ------
+== Fix bash 3.2 compatibility
+`pgtle.sh` used `${#ARRAY[@]:-0}` which is a syntax error in bash 3.2
+("bad substitution"). Changed to `${#ARRAY[@]}`, which correctly returns
+0 for empty arrays in all bash versions. `base.mk` now deduplicates `DOCS`
+when adding generated HTML to prevent duplicate install entries when HTML
+files are already included by wildcard.
+
 == Remove .source file support
 PostgreSQL removed `.source` file processing from `pg_regress` in PG15.
 The `input/*.source` → `sql/*.sql` and `output/*.source` →

--- a/base.mk
+++ b/base.mk
@@ -204,8 +204,9 @@ dist: html
 # But don't add it as an install or test dependency unless we do have asciidoc
 ifneq (,$(strip $(ASCIIDOC)))
 
-# Need to do this so install & co will pick up ALL targets. Unfortunately this can result in some duplication.
-DOCS += $(ASCIIDOC_HTML)
+# Add HTML to DOCS for install, deduplicating against any HTML already picked
+# up by the wildcard (e.g. pre-built HTML committed to the repo).
+DOCS := $(sort $(filter-out $(ASCIIDOC_HTML),$(DOCS)) $(ASCIIDOC_HTML))
 
 # Also need to add html as a dep to all (which will get picked up by install & installcheck
 all: html

--- a/build_meta.sh
+++ b/build_meta.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build META.json from META.in.json template
 #

--- a/lib.sh
+++ b/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # lib.sh - Common utility functions for pgxntool scripts
 #
 # This file is meant to be sourced by other scripts, not executed directly.

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -564,8 +564,8 @@ discover_sql_files() {
         echo "    - $f" >&2
     done
 
-    debug 30 "discover_sql_files: Checking UPGRADE_FILES array, count=${#UPGRADE_FILES[@]:-0}"
-    if [ ${#UPGRADE_FILES[@]:-0} -gt 0 ]; then
+    debug 30 "discover_sql_files: Checking UPGRADE_FILES array, count=${#UPGRADE_FILES[@]}"
+    if [ ${#UPGRADE_FILES[@]} -gt 0 ]; then
         echo "  Found ${#UPGRADE_FILES[@]} upgrade script(s):" >&2
         debug 30 "discover_sql_files: Iterating over ${#UPGRADE_FILES[@]} upgrade files"
         for f in "${UPGRADE_FILES[@]}"; do
@@ -633,8 +633,8 @@ build_requires_array() {
 generate_header() {
     local pgtle_version="$1"
     local output_file="$2"
-    local version_count=${#VERSION_FILES[@]:-0}
-    local upgrade_count=${#UPGRADE_FILES[@]:-0}
+    local version_count=${#VERSION_FILES[@]}
+    local upgrade_count=${#UPGRADE_FILES[@]}
 
     # Determine version compatibility message
     local compat_msg
@@ -760,8 +760,8 @@ generate_pgtle_sql() {
     # Ensure arrays are initialized (defensive programming)
     # Arrays should already be initialized at top level, but ensure they exist
     debug 30 "generate_pgtle_sql: Checking array initialization"
-    debug 30 "generate_pgtle_sql: VERSION_FILES is ${VERSION_FILES+set}, count=${#VERSION_FILES[@]:-0}"
-    debug 30 "generate_pgtle_sql: UPGRADE_FILES is ${UPGRADE_FILES+set}, count=${#UPGRADE_FILES[@]:-0}"
+    debug 30 "generate_pgtle_sql: VERSION_FILES is ${VERSION_FILES+set}, count=${#VERSION_FILES[@]}"
+    debug 30 "generate_pgtle_sql: UPGRADE_FILES is ${UPGRADE_FILES+set}, count=${#UPGRADE_FILES[@]}"
     
     if [ -z "${VERSION_FILES+set}" ]; then
         echo "WARNING: VERSION_FILES not set, initializing" >&2
@@ -819,7 +819,7 @@ EOF
         fi
 
         # Install all upgrade paths
-        local upgrade_count=${#UPGRADE_FILES[@]:-0}
+        local upgrade_count=${#UPGRADE_FILES[@]}
         debug 30 "generate_pgtle_sql: upgrade_count=$upgrade_count"
         if [ "$upgrade_count" -gt 0 ]; then
             debug 30 "generate_pgtle_sql: Processing $upgrade_count upgrade path(s)"

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # pgtle.sh - Generate pg_tle registration SQL for PostgreSQL extensions
 #


### PR DESCRIPTION
Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/12

## Changes

**bash 3.2 syntax fix (`pgtle.sh`)**
- Replace `${#ARRAY[@]:-0}` with `${#ARRAY[@]}` throughout `pgtle.sh`
- `${#ARRAY[@]:-0}` is a fatal syntax error ("bad substitution") in bash 3.2 — the `:-` default modifier cannot be applied to an array length expression
- `${#ARRAY[@]}` correctly returns 0 for empty arrays in all bash versions

**DOCS deduplication (`base.mk`)**
- Deduplicate `DOCS` when adding generated HTML, preventing duplicate install entries when HTML is already included by the wildcard

**Shebang portability (all shell scripts)**
- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in `pgtle.sh`, `build_meta.sh`, and `lib.sh`
- `/bin/bash` fails on systems where bash lives elsewhere (some BSDs, NixOS, Homebrew on macOS)