### PR TITLE
Fix broken ifeq for --load-language=plpgsql on PG < 13

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -205,7 +205,7 @@ ifeq ($(GE91),yes)
 all: $(EXTENSION_VERSION_FILES)
 endif
 
-ifeq ($($call test, $(MAJORVER), -lt 13), yes)
+ifeq ($(call test, $(MAJORVER), -lt, 130), yes)
 	REGRESS_OPTS += --load-language=plpgsql
 endif
 


### PR DESCRIPTION
Fix three syntax errors in the `ifeq` that adds `--load-language=plpgsql` for
PostgreSQL < 13:

- `$($call` → `$(call` (extra `$` prevented macro expansion)
- `-lt 13` → `-lt, 130` (missing comma separator between operator and value)
- `13` → `130` (`MAJORVER` is version × 10, matching the pattern on line 202)

The condition never evaluated to true, so `--load-language=plpgsql` was never
added. This only affects PostgreSQL < 13, which removed `--load-language` from
`pg_regress` entirely.

No related changes in pgxntool-test.