### PR TITLE
Fix parse_control_file: remove comments before stripping quotes

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,10 @@
+STABLE
+------
+== Fix parse_control_file corrupting values with trailing comments
+Control file values like `default_version = '1.0.0' # comment` were parsed
+incorrectly — the trailing quote was left in the value due to comment removal
+happening after quote stripping. Fixed by removing comments first.
+
 2.0.1
 -----
 == Improve bash compatibility (specifically for Mac OS)

--- a/pgtle.sh
+++ b/pgtle.sh
@@ -459,15 +459,17 @@ parse_control_file() {
             local key="${BASH_REMATCH[1]}"
             local value="${BASH_REMATCH[2]}"
 
+            # Trim trailing comments and whitespace FIRST, then strip quotes.
+            # Order matters: stripping quotes before removing comments leaves a rogue
+            # trailing quote for values like 'version' # note. See issue #25.
+            value="${value%%#*}"  # Remove trailing comments
+            value="${value%% }"   # Trim trailing whitespace
+
             # Strip quotes if present (both single and double)
             value="${value#\'}"
             value="${value%\'}"
             value="${value#\"}"
             value="${value%\"}"
-
-            # Trim trailing whitespace/comments
-            value="${value%%#*}"  # Remove trailing comments
-            value="${value%% }"   # Trim trailing spaces
 
             # Store in global variables
             case "$key" in


### PR DESCRIPTION
`parse_control_file` was stripping quotes before removing trailing comments, corrupting values. For a line like `default_version = '1.0.0' # comment`, the leading `'` was stripped first, leaving `1.0.0' # comment`; then the trailing `'` wasn't matched (comment was last), leaving a rogue `'` in the value.

Fix: swap the order — remove trailing comments and whitespace first, then strip quotes. This matches the correct order already used by the sibling function `get_control_default_version` in `control.mk.sh`.

Fixes #25.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/17
