### PR TITLE
Fix pgxntool-sync remote and make it runnable without make

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,10 @@ When tests fail, examine the diff output carefully. The actual test output in `t
 - Validates repo is clean before tagging
 
 ### Subtree Sync Support
-- `make pgxntool-sync` pulls latest release
-- Multiple sync targets: release, stable, local variants
-- Uses `git subtree pull --squash`
+- `make pgxntool-sync` pulls the latest release (the `release` tag) from the canonical repo
+- `pgxntool/pgxntool-sync.sh [<repo> [<ref>]]` does the work and can be run without make
+- `make pgxntool-sync-<name>` pulls from the `pgxntool-sync-<name>` variable (`<repo> <ref>`)
+- Uses `git subtree pull --squash`, then `update-setup-files.sh` for a 3-way merge of copied files
 - Requires clean repo (no uncommitted changes)
 
 ### pg_tle Support

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,16 +1,11 @@
 STABLE
 ------
 == Fix pgxntool-sync remote, and make it runnable without make
-`make pgxntool-sync` pulled from `git@github.com:decibel/pgxntool.git` -- the
-old owner, over SSH, which fails for anyone without GitHub SSH keys set up. It
-now pulls from `https://github.com/Postgres-Extensions/pgxntool.git` over HTTPS.
-The ref is unchanged: the `release` tag, which the release process force-moves
-to each new version so it always names the latest released version.
-
-The subtree pull + `update-setup-files.sh` logic previously lived inline in the
-Makefile recipe. It now lives in `pgxntool/pgxntool-sync.sh`, so you can update
-pgxntool without `make`: run `pgxntool/pgxntool-sync.sh` from your project root.
-The make targets are thin wrappers around it.
+`make pgxntool-sync` pointed at the old owner's SSH URL, which fails without
+GitHub SSH keys; it now uses `https://github.com/Postgres-Extensions/pgxntool.git`
+over HTTPS (still the `release` tag). The subtree pull + `update-setup-files.sh`
+logic moved into `pgxntool/pgxntool-sync.sh`, which the make targets now wrap, so
+you can also sync without `make` by running it directly.
 
 2.0.2
 -----

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,17 @@
+STABLE
+------
+== Fix pgxntool-sync remote, and make it runnable without make
+`make pgxntool-sync` pulled from `git@github.com:decibel/pgxntool.git` -- the
+old owner, over SSH, which fails for anyone without GitHub SSH keys set up. It
+now pulls from `https://github.com/Postgres-Extensions/pgxntool.git` over HTTPS.
+The ref is unchanged: the `release` tag, which the release process force-moves
+to each new version so it always names the latest released version.
+
+The subtree pull + `update-setup-files.sh` logic previously lived inline in the
+Makefile recipe. It now lives in `pgxntool/pgxntool-sync.sh`, so you can update
+pgxntool without `make`: run `pgxntool/pgxntool-sync.sh` from your project root.
+The make targets are thin wrappers around it.
+
 2.0.2
 -----
 == Fix parse_control_file corrupting values with trailing comments

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,7 +1,7 @@
 STABLE
 ------
 == Fix pgxntool-sync remote, and make it runnable without make
-`make pgxntool-sync` pointed at the old owner's SSH URL, which fails without
+`make pgxntool-sync` pointed at the old SSH URL, which fails without
 GitHub SSH keys; it now uses `https://github.com/Postgres-Extensions/pgxntool.git`
 over HTTPS (still the `release` tag). The subtree pull + `update-setup-files.sh`
 logic moved into `pgxntool/pgxntool-sync.sh`, which the make targets now wrap, so

--- a/README.asc
+++ b/README.asc
@@ -223,11 +223,13 @@ WARNING: You will be very unhappy if you forget to update the .control file for 
 NOTE: Part of the `clean` recipe is cleaning up these .zip files. If you accidentally clean before uploading, just run `make dist-only`.
 
 === pgxntool-sync
-This rule will pull down the latest released version of PGXNtool via `git subtree pull`.
+This rule will pull down the latest released version of PGXNtool via `git subtree pull` and then reconcile the files `setup.sh` copied into your project (`.gitignore`, `test/deps.sql`) with a 3-way merge.
 
 NOTE: Your repository must be clean (no modified files) in order to run this. Running this command will produce a git commit of the merge.
 
-TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things.
+TIP: The actual work is done by `pgxntool/pgxntool-sync.sh`, so you can run it directly (`pgxntool/pgxntool-sync.sh`) if you'd rather not go through `make`. It optionally takes `<repo>` and `<ref>` arguments to pull from somewhere other than the default.
+
+TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things. `make pgxntool-sync-<name>` pulls from the `<repo> <ref>` defined by the `pgxntool-sync-<name>` make variable.
 
 === distclean
 `make distclean` removes generated configuration files (`META.json`, `meta.mk`, `control.mk`) that survive a normal `make clean`.

--- a/README.html
+++ b/README.html
@@ -926,7 +926,7 @@ Part of the <code>clean</code> recipe is cleaning up these .zip files. If you ac
 <div class="sect2">
 <h3 id="_pgxntool_sync"><a class="anchor" href="#_pgxntool_sync"></a><a class="link" href="#_pgxntool_sync">4.9. pgxntool-sync</a></h3>
 <div class="paragraph">
-<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code>.</p>
+<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code> and then reconcile the files <code>setup.sh</code> copied into your project (<code>.gitignore</code>, <code>test/deps.sql</code>) with a 3-way merge.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -947,7 +947,19 @@ Your repository must be clean (no modified files) in order to run this. Running 
 <div class="title">Tip</div>
 </td>
 <td class="content">
-There is also a <code>pgxntool-sync-%</code> rule if you need to do more advanced things.
+The actual work is done by <code>pgxntool/pgxntool-sync.sh</code>, so you can run it directly (<code>pgxntool/pgxntool-sync.sh</code>) if you&#8217;d rather not go through <code>make</code>. It optionally takes <code>&lt;repo&gt;</code> and <code>&lt;ref&gt;</code> arguments to pull from somewhere other than the default.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+There is also a <code>pgxntool-sync-%</code> rule if you need to do more advanced things. <code>make pgxntool-sync-&lt;name&gt;</code> pulls from the <code>&lt;repo&gt; &lt;ref&gt;</code> defined by the <code>pgxntool-sync-&lt;name&gt;</code> make variable.
 </td>
 </tr>
 </table>

--- a/base.mk
+++ b/base.mk
@@ -499,11 +499,12 @@ pgxntool-sync-%:
 
 # DANGER! Use these with caution. They may add extra crap to your history and
 # could make resolving merges difficult!
-# The `release` tag is a floating tag that always points at the latest release.
-pgxntool-sync-upstream		:= https://github.com/Postgres-Extensions/pgxntool.git release
-pgxntool-sync-upstream-master	:= https://github.com/Postgres-Extensions/pgxntool.git master
-pgxntool-sync-local		:= ../pgxntool release # Not the same as PGXNTOOL_DIR!
-pgxntool-sync-local-master	:= ../pgxntool master # Not the same as PGXNTOOL_DIR!
+# `pgxntool-sync` (no suffix) already pulls the canonical release; these are the
+# alternatives. `-master` pulls the bleeding edge; `-local*` pull from a sibling
+# ../pgxntool checkout (not the same as PGXNTOOL_DIR!).
+pgxntool-sync-master		:= https://github.com/Postgres-Extensions/pgxntool.git master
+pgxntool-sync-local		:= ../pgxntool release
+pgxntool-sync-local-master	:= ../pgxntool master
 
 # PGXS doesn't provide any special support for distclean (it just depends on
 # clean), so we roll our own. Files that should only be removed by distclean

--- a/base.mk
+++ b/base.mk
@@ -482,26 +482,27 @@ print-%	: ; $(info $* is $(flavor $*) variable set to "$($*)") @true
 #
 # subtree sync support
 #
-# This is setup to allow any number of pull targets by defining special
-# variables. pgxntool-sync-release is an example of this.
+# All the real work (git subtree pull + update-setup-files.sh) lives in
+# pgxntool/pgxntool-sync.sh so it can be run directly, without make. These
+# targets are thin wrappers around that script.
 #
-# After the subtree pull, we run update-setup-files.sh to handle files that
-# were initially copied by setup.sh (like .gitignore). This script does a
-# 3-way merge if both you and pgxntool changed the file.
-.PHONY: pgxntool-sync-%
+# `make pgxntool-sync` pulls the latest released version from the canonical
+# repository (the script's built-in default).
+#
+# `make pgxntool-sync-<name>` pulls from the "<repo> <ref>" defined by the
+# pgxntool-sync-<name> variable, allowing any number of custom pull sources.
+.PHONY: pgxntool-sync pgxntool-sync-%
+pgxntool-sync:
+	@pgxntool/pgxntool-sync.sh
 pgxntool-sync-%:
-	@old_commit=$$(git log -1 --format=%H -- pgxntool/) && \
-	git subtree pull -P pgxntool --squash -m "Pull pgxntool from $($@)" $($@) && \
-	pgxntool/update-setup-files.sh "$$old_commit"
-pgxntool-sync: pgxntool-sync-release
+	@pgxntool/pgxntool-sync.sh $($@)
 
 # DANGER! Use these with caution. They may add extra crap to your history and
 # could make resolving merges difficult!
-pgxntool-sync-release	:= git@github.com:decibel/pgxntool.git release
-pgxntool-sync-stable	:= git@github.com:decibel/pgxntool.git stable
-pgxntool-sync-master	:= git@github.com:decibel/pgxntool.git master
+# The `release` tag is a floating tag that always points at the latest release.
+pgxntool-sync-upstream		:= https://github.com/Postgres-Extensions/pgxntool.git release
+pgxntool-sync-upstream-master	:= https://github.com/Postgres-Extensions/pgxntool.git master
 pgxntool-sync-local		:= ../pgxntool release # Not the same as PGXNTOOL_DIR!
-pgxntool-sync-local-stable	:= ../pgxntool stable # Not the same as PGXNTOOL_DIR!
 pgxntool-sync-local-master	:= ../pgxntool master # Not the same as PGXNTOOL_DIR!
 
 # PGXS doesn't provide any special support for distclean (it just depends on

--- a/pgxntool-sync.sh
+++ b/pgxntool-sync.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# pgxntool-sync.sh - Pull the latest pgxntool via git subtree and reconcile setup files
+#
+# This performs the two steps needed to update pgxntool inside a project:
+#
+#   1. git subtree pull -P pgxntool ...   (update the embedded pgxntool copy)
+#   2. update-setup-files.sh <old-commit> (3-way merge files setup.sh copied out,
+#                                           like .gitignore and test/deps.sql)
+#
+# It is invoked by the `make pgxntool-sync` targets, but can also be run directly
+# so you never need make to update pgxntool.
+#
+# Usage: pgxntool-sync.sh [<repo> [<ref>]]
+#
+#   repo  Git URL (or path) to pull pgxntool from. Defaults to the canonical
+#         pgxntool repository.
+#   ref   Branch, tag, or commit to pull. Defaults to the `release` tag, which
+#         always points at the latest released version.
+#
+# Run from the root of your project (the directory containing pgxntool/).
+
+set -o errexit -o errtrace -o pipefail
+trap 'echo "Error on line ${LINENO}"' ERR
+
+PGXNTOOL_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "$PGXNTOOL_DIR/lib.sh"
+
+# Canonical source for pgxntool. `release` is a floating tag that the release
+# process force-moves to each new version, so it always names the latest
+# released version -- exactly what a plain sync should track.
+DEFAULT_REPO="https://github.com/Postgres-Extensions/pgxntool.git"
+DEFAULT_REF="release"
+
+repo=${1:-$DEFAULT_REPO}
+ref=${2:-$DEFAULT_REF}
+
+# We must run from the project root: git subtree pull operates on the pgxntool/
+# prefix and update-setup-files.sh resolves paths relative to the current dir.
+[[ -d "pgxntool" ]] || die 1 "pgxntool directory not found. Run from your project root."
+[[ -d ".git" ]] || die 1 "Not in a git repository. Run from your project root."
+
+# The old commit is the pgxntool subtree HEAD before the pull; update-setup-files.sh
+# needs it as the merge base for files that were copied out of pgxntool.
+old_commit=$(git log -1 --format=%H -- pgxntool/)
+
+git subtree pull -P pgxntool --squash -m "Pull pgxntool from $repo $ref" "$repo" "$ref"
+
+"$PGXNTOOL_DIR/update-setup-files.sh" "$old_commit"


### PR DESCRIPTION
## What

`make pgxntool-sync` pulled from `git@github.com:decibel/pgxntool.git` (the `release` tag) -- the old owner, over SSH, so it failed for anyone without GitHub SSH keys configured. It now pulls from `https://github.com/Postgres-Extensions/pgxntool.git` over HTTPS. The ref is unchanged: the `release` tag, which the release process force-moves to each version so it always names the latest released version.

The subtree pull + `update-setup-files.sh` logic was extracted from the inline Makefile recipe into `pgxntool/pgxntool-sync.sh`. You can now update pgxntool without make:

    pgxntool/pgxntool-sync.sh [<repo> [<ref>]]

`make pgxntool-sync` and `make pgxntool-sync-<name>` are thin wrappers around the script.

## Sync targets

- `pgxntool-sync` -> Postgres-Extensions `release` tag (the default)
- `pgxntool-sync-master` -> Postgres-Extensions `master`
- `pgxntool-sync-local` / `pgxntool-sync-local-master` -> sibling `../pgxntool` checkout, `release` / `master`
- `-stable` variants removed (no such branch/tag exists)

Verified against the real remote: both the default (`release`) and `master` complete a subtree pull + setup-file reconcile. The offline test suite verifies each target's wiring via `make -n`.

Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/23

🤖 Generated with [Claude Code](https://claude.com/claude-code)