### PR TITLE
Fix repo-root guard to work inside a git worktree

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,12 @@
+STABLE
+------
+== Fix setup.sh / pgxntool-sync.sh / update-setup-files.sh inside a git worktree
+These scripts guarded the project root with `[ -d .git ]`. In a linked worktree
+`.git` is a file, not a directory, so the check failed: setup.sh would wrongly
+re-run `git init`, and the sync scripts aborted with "Not in a git repository."
+They now detect the repo with `git rev-parse --git-dir`, which works in both a
+normal clone and a worktree.
+
 2.0.3
 -----
 == Fix pgxntool-sync remote, and make it runnable without make

--- a/pgxntool-sync.sh
+++ b/pgxntool-sync.sh
@@ -38,7 +38,8 @@ ref=${2:-$DEFAULT_REF}
 # We must run from the project root: git subtree pull operates on the pgxntool/
 # prefix and update-setup-files.sh resolves paths relative to the current dir.
 [[ -d "pgxntool" ]] || die 1 "pgxntool directory not found. Run from your project root."
-[[ -d ".git" ]] || die 1 "Not in a git repository. Run from your project root."
+# Use rev-parse, not [ -d .git ]: in a worktree .git is a file, not a directory.
+git rev-parse --git-dir >/dev/null 2>&1 || die 1 "Not in a git repository. Run from your project root."
 
 # The old commit is the pgxntool subtree HEAD before the pull; update-setup-files.sh
 # needs it as the merge base for files that were copied out of pgxntool.

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,9 @@ trap 'echo "Error on line ${LINENO}"' ERR
 PGXNTOOL_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "$PGXNTOOL_DIR/lib.sh"
 
-[ -d .git ] || git init
+# Use rev-parse, not [ -d .git ]: in a worktree .git is a file, not a directory,
+# so the old check would wrongly re-run `git init` inside a valid working tree.
+git rev-parse --git-dir >/dev/null 2>&1 || git init
 
 if ! git diff --cached --exit-code; then
     echo "Git repository is not clean; please commit and try again." >&2

--- a/update-setup-files.sh
+++ b/update-setup-files.sh
@@ -146,9 +146,10 @@ process_symlink() {
 
 old_commit=$1
 
-# Verify we're in a git repo with pgxntool subtree
+# Verify we're in a git repo with pgxntool subtree.
+# Use rev-parse, not [ -d .git ]: in a worktree .git is a file, not a directory.
 [[ -d "pgxntool" ]] || die 1 "pgxntool directory not found. Run from project root."
-[[ -d ".git" ]] || die 1 "Not in a git repository."
+git rev-parse --git-dir >/dev/null 2>&1 || die 1 "Not in a git repository."
 
 # Verify the old commit is valid
 if ! git cat-file -e "${old_commit}^{commit}" 2>/dev/null; then


### PR DESCRIPTION
Fixes #38.

`setup.sh`, `pgxntool-sync.sh`, and `update-setup-files.sh` guarded the project root with `[ -d .git ]`. In a linked git worktree (`git worktree add`), `.git` is a *file* (a `gitdir:` pointer), not a directory, so the guard failed on a perfectly valid working tree:

- `setup.sh` wrongly re-ran `git init`
- the sync scripts aborted with `ERROR: Not in a git repository.`

All three now detect the repo with `git rev-parse --git-dir`, which works in both a normal clone and a worktree.

## Verification

- Reproduced the failure with the old guard and confirmed the fix passes, running the script from inside a real worktree.
- Full suite green (212/212) on PG 17.

Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)