### PR TITLE
ci: pass repo owners to run-tests.yml for fork-account matching

### DIFF
--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,0 +1,1 @@
+trigger

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,1 +1,0 @@
-trigger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,5 +285,10 @@ jobs:
     # -----------------------------------------------------------------------
     uses: Postgres-Extensions/pgxntool-test/.github/workflows/run-tests.yml@master
     with:
+      # pgxntool: this PR's own branch, on its own account (a fork for fork PRs).
+      pgxntool-owner: ${{ github.event.pull_request.head.repo.owner.login }}
       pgxntool-branch: ${{ github.event.pull_request.head.ref }}
+      # pgxntool-test: no paired test PR in this path, so use canonical master
+      # from Postgres-Extensions only (never a fork's master).
+      pgxntool-test-owner: Postgres-Extensions
       pgxntool-test-ref: master

--- a/README.asc
+++ b/README.asc
@@ -25,7 +25,9 @@ TODO: Create a nice script that will init a new project for you.
 
 == Development
 
-If you want to contribute to pgxntool development, work from the https://github.com/decibel/pgxntool-test[pgxntool-test] repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via `git subtree`.
+If you want to contribute to pgxntool development, work from the https://github.com/Postgres-Extensions/pgxntool-test[pgxntool-test] repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via `git subtree`.
+
+Changes are normally paired across both repos: a `pgxntool` change should come with a matching branch (same name, on the same account) and PR in `pgxntool-test`, and CI enforces this pairing. See the https://github.com/Postgres-Extensions/pgxntool-test#ci-and-contributing[CI and Contributing] section in pgxntool-test for the full workflow.
 
 == Usage
 Typically, you can just create a simple Makefile that does nothing but include base.mk:

--- a/README.html
+++ b/README.html
@@ -542,7 +542,10 @@ pgxntool/setup.sh</pre>
 <h2 id="_development"><a class="anchor" href="#_development"></a><a class="link" href="#_development">2. Development</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>If you want to contribute to pgxntool development, work from the <a href="https://github.com/decibel/pgxntool-test">pgxntool-test</a> repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via <code>git subtree</code>.</p>
+<p>If you want to contribute to pgxntool development, work from the <a href="https://github.com/Postgres-Extensions/pgxntool-test">pgxntool-test</a> repository, not from this repository. That repository contains the test infrastructure and development tools needed to validate changes to pgxntool. This repository contains only the framework files that get embedded into extension projects via <code>git subtree</code>.</p>
+</div>
+<div class="paragraph">
+<p>Changes are normally paired across both repos: a <code>pgxntool</code> change should come with a matching branch (same name, on the same account) and PR in <code>pgxntool-test</code>, and CI enforces this pairing. See the <a href="https://github.com/Postgres-Extensions/pgxntool-test#ci-and-contributing">CI and Contributing</a> section in pgxntool-test for the full workflow.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Pairs with pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/25

## Problem
CI resolved the paired sibling branch using `github.repository_owner`
(Postgres-Extensions), so a **fork PR** never found its paired branch (which
lives on the fork) and tested against the wrong, unpaired code. This is what
made the fix-38 PRs' CI fail: pgxntool-test's resolve looked for the pgxntool
branch on Postgres-Extensions, didn't find it (it was on the fork), fell back to
`pgxntool=master`, and master lacked the paired change.

## This PR (pgxntool side)
When pgxntool runs its own tests (`commit-with-no-tests` or master-to-master),
pass explicit owners to `run-tests.yml`:
- `pgxntool-owner` = this PR's head account (the fork for fork PRs)
- `pgxntool-test-owner` = `Postgres-Extensions` (canonical master only — never a fork's master)

The matching resolve/owner logic and the `pgxntool-owner`/`pgxntool-test-owner`
inputs on `run-tests.yml` are in the paired pgxntool-test PR.

**Merge order:** pgxntool-test first (so `run-tests.yml@master` gains the owner
inputs), then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)