### PR TITLE
README.asc: make tag creates a git tag, not a branch

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -213,14 +213,14 @@ make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results
 ----
 
 === tag
-`make tag` will create a git branch for the current version of your extension, as determined by the META.json file. The reason to do this is so you can always refer to the exact code that went into a released version.
+`make tag` will create an annotated git tag for the current version of your extension, as determined by the META.json file, and push it to `origin`. The reason to do this is so you can always refer to the exact code that went into a released version.
 
 If there's already a tag for the current version that probably means you forgot to update META.json, so you'll get an error. If you're certain you want to over-write the tag, you can do `make forcetag`, which removes the existing tag (via `make rmtag`) and creates a new one.
 
 WARNING: You will be very unhappy if you forget to update the .control file for your extension! There is an https://github.com/decibel/pgxntool/issues/1[open issue] to improve this.
 
 === dist
-`make dist` will create a .zip file for your current version that you can upload to PGXN. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json). The .zip file is placed in the *parent* directory so as not to clutter up your git repo.
+`make dist` will create a .zip file for your current version that you can upload to PGXN. It first runs `tag` (creating/pushing the version's git tag as described above if needed), then uses `git archive` at that tag to build the .zip file, so the archive always matches the exact tagged commit. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json). The .zip file is placed in the *parent* directory so as not to clutter up your git repo.
 
 NOTE: Part of the `clean` recipe is cleaning up these .zip files. If you accidentally clean before uploading, just run `make dist-only`.
 


### PR DESCRIPTION
Fixes #46.

`make tag`/`make dist` create and push a real annotated git tag (`git tag $(PGXNVERSION)`, `git push origin $(PGXNVERSION)`), then `git archive` at that tag for `make dist` — README.asc still described `make tag` as creating a git branch. Updated the `tag` and `dist` sections in README.asc to describe the actual tag-based behavior.

Doc-only change, no code changes.