### PR TITLE
pgtle_versions.md: fix wrong uninstall_extension() version claim

### DIFF
--- a/pgtle_versions.md
+++ b/pgtle_versions.md
@@ -7,13 +7,12 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 ### 1.0.0-1.4.0
 - **pg_tle versions:** 1.0.0 through 1.3.x
 - **PostgreSQL support:** 11-17
-- **API:** No schema parameter on `install_extension()`
 - **Features:** Basic extension management, custom data types, authentication hooks
 
 ### 1.4.0-1.5.0
 - **pg_tle versions:** 1.4.0 through 1.4.x
 - **PostgreSQL support:** 11-17
-- **API:** `install_extension()` still has no schema parameter. Added alignment/storage parameters to `pgtle.create_base_type()`
+- **API:** Added alignment/storage parameters to `pgtle.create_base_type()`
 - **Features:** Custom alignment/storage, enhanced warnings
 
 ### 1.5.0+
@@ -24,8 +23,7 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 
 ## Key API Changes by Version
 
-**1.4.0:** No change to `install_extension()`
-- Added alignment/storage parameters to `pgtle.create_base_type()` (see Features above)
+**1.4.0:** Added alignment/storage parameters to `pgtle.create_base_type()` (see Features above)
 
 **1.5.0:** Changed `pgtle.install_extension()` signature
 - Added required `schema` parameter

--- a/pgtle_versions.md
+++ b/pgtle_versions.md
@@ -7,13 +7,13 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 ### 1.0.0-1.4.0
 - **pg_tle versions:** 1.0.0 through 1.3.x
 - **PostgreSQL support:** 11-17
-- **API:** No `pgtle.uninstall_extension()` function, no schema parameter
+- **API:** `pgtle.uninstall_extension(extname text)` present and unchanged since 1.0.0 (as is the `uninstall_extension(extname text, version text)` overload); no schema parameter on `install_extension()`
 - **Features:** Basic extension management, custom data types, authentication hooks
 
 ### 1.4.0-1.5.0
 - **pg_tle versions:** 1.4.0 through 1.4.x
 - **PostgreSQL support:** 11-17
-- **API:** Added `pgtle.uninstall_extension()` function, no schema parameter
+- **API:** No install/uninstall API change from the prior range - `uninstall_extension()` is unchanged and `install_extension()` still has no schema parameter. The 1.4.0 release instead added alignment/storage parameters to `pgtle.create_base_type()`
 - **Features:** Custom alignment/storage, enhanced warnings
 
 ### 1.5.0+
@@ -24,8 +24,10 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 
 ## Key API Changes by Version
 
-**1.4.0:** Added `pgtle.uninstall_extension()`
-- Versions before 1.4.0 cannot uninstall extensions
+**1.4.0:** No change to `install_extension()` or `uninstall_extension()`
+- `pgtle.uninstall_extension(extname text)` has existed unchanged since pg_tle 1.0.0 (confirmed against the tagged source: `pg_tle--1.0.0.sql` already defines it, and `pg_tle--1.3.4--1.4.0.sql` makes no install/uninstall changes)
+- What was added in 1.0.1-1.0.4 (still within this range) was a body-only change to the existing `uninstall_extension(extname text, version text)` overload (added default-version protection logic), not a new overload
+- Added alignment/storage parameters to `pgtle.create_base_type()` (see Features above)
 
 **1.5.0:** Changed `pgtle.install_extension()` signature
 - Added required `schema` parameter

--- a/pgtle_versions.md
+++ b/pgtle_versions.md
@@ -23,9 +23,10 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 
 ## Key API Changes by Version
 
-**1.4.0:** Added alignment/storage parameters to `pgtle.create_base_type()` (see Features above)
+**1.4.0:** Added alignment/storage parameters to `pgtle.create_base_type()`
 
-**1.5.0:** Changed `pgtle.install_extension()` signature
+**1.5.0**
+- Changed `pgtle.install_extension()` signature
 - Added required `schema` parameter
 - Dropped PostgreSQL 11 support
 

--- a/pgtle_versions.md
+++ b/pgtle_versions.md
@@ -7,13 +7,13 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 ### 1.0.0-1.4.0
 - **pg_tle versions:** 1.0.0 through 1.3.x
 - **PostgreSQL support:** 11-17
-- **API:** `pgtle.uninstall_extension(extname text)` present and unchanged since 1.0.0 (as is the `uninstall_extension(extname text, version text)` overload); no schema parameter on `install_extension()`
+- **API:** No schema parameter on `install_extension()`
 - **Features:** Basic extension management, custom data types, authentication hooks
 
 ### 1.4.0-1.5.0
 - **pg_tle versions:** 1.4.0 through 1.4.x
 - **PostgreSQL support:** 11-17
-- **API:** No install/uninstall API change from the prior range - `uninstall_extension()` is unchanged and `install_extension()` still has no schema parameter. The 1.4.0 release instead added alignment/storage parameters to `pgtle.create_base_type()`
+- **API:** `install_extension()` still has no schema parameter. Added alignment/storage parameters to `pgtle.create_base_type()`
 - **Features:** Custom alignment/storage, enhanced warnings
 
 ### 1.5.0+
@@ -24,9 +24,7 @@ This file documents pg_tle version boundaries that affect pgxntool's pg_tle supp
 
 ## Key API Changes by Version
 
-**1.4.0:** No change to `install_extension()` or `uninstall_extension()`
-- `pgtle.uninstall_extension(extname text)` has existed unchanged since pg_tle 1.0.0 (confirmed against the tagged source: `pg_tle--1.0.0.sql` already defines it, and `pg_tle--1.3.4--1.4.0.sql` makes no install/uninstall changes)
-- What was added in 1.0.1-1.0.4 (still within this range) was a body-only change to the existing `uninstall_extension(extname text, version text)` overload (added default-version protection logic), not a new overload
+**1.4.0:** No change to `install_extension()`
 - Added alignment/storage parameters to `pgtle.create_base_type()` (see Features above)
 
 **1.5.0:** Changed `pgtle.install_extension()` signature


### PR DESCRIPTION
Fixes #54.

`pgtle_versions.md` claimed `pgtle.uninstall_extension()` was added in pg_tle 1.4.0. Checking the tagged pg_tle source directly (`pg_tle--1.0.0.sql`, `pg_tle--1.0.1--1.0.4.sql`, `pg_tle--1.3.4--1.4.0.sql`, `pg_tle--1.4.0--1.5.0.sql`) shows:

- `uninstall_extension(extname text)` and the `(extname text, version text)` overload have both existed unchanged since v1.0.0
- The 1.0.1-1.0.4 change was a body-only update to the two-arg overload (default-version protection logic), not a new overload
- The actual 1.4.0 release only changed `create_base_type()` (added alignment/storage params) — no install/uninstall change
- The real install/uninstall API break is at 1.5.0, where `install_extension()` gains a required `schema` parameter

Corrected the `1.0.0-1.4.0` / `1.4.0-1.5.0` range descriptions and the "Key API Changes by Version" section to reflect this. Doesn't change any generated SQL or code — the version-range split pgxntool uses is still correct, only the doc's stated rationale was wrong.

Doc-only change, no code changes.