### PR TITLE
Rename EXTENSION_VERSION_FILES to EXTENSION__CURRENT_VERSION__FILES

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ include pgxntool/base.mk
   - `PGXNVERSION` - version number
   - `EXTENSIONS` - list of extensions provided
   - `EXTENSION_*_VERSION` - per-extension versions
-  - `EXTENSION_VERSION_FILES` - auto-generated versioned SQL files
+  - `EXTENSION__CURRENT_VERSION__FILES` - auto-generated versioned SQL files
 - `base.mk` includes `meta.mk` via `-include`
 
 ### The Magic of base.mk

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,5 +1,11 @@
 STABLE
 ------
+== Rename `EXTENSION_VERSION_FILES` to `EXTENSION__CURRENT_VERSION__FILES`
+The old name implied it listed every version file for an extension; it
+actually only ever holds the current/most-recent one per extension. If your
+Makefile references `EXTENSION_VERSION_FILES` directly (e.g. to add extra
+dependencies to `DATA`), update it to `EXTENSION__CURRENT_VERSION__FILES`.
+
 == Fix `pgtle.sh` rejecting non-numeric version aliases like `stable`
 `extract_version_from_filename()` required every version segment to start
 with a digit, so extensions using a persistent `stable` pseudo-version

--- a/base.mk
+++ b/base.mk
@@ -37,7 +37,7 @@ control.mk: $(PGXNTOOL_CONTROL_FILES) Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOO
 
 -include control.mk
 
-DATA         = $(EXTENSION_VERSION_FILES) $(wildcard sql/*--*--*.sql)
+DATA         = $(EXTENSION__CURRENT_VERSION__FILES) $(wildcard sql/*--*--*.sql)
 DOC_DIRS	+= doc
 # NOTE: if this is empty it gets forcibly defined to NUL before including PGXS
 DOCS		+= $(foreach dir,$(DOC_DIRS),$(wildcard $(dir)/*))
@@ -206,7 +206,7 @@ test		 = $(shell test $(1) $(2) $(3) && echo yes || echo no)
 GE91		 = $(call test, $(MAJORVER), -ge, 91)
 
 ifeq ($(GE91),yes)
-all: $(EXTENSION_VERSION_FILES)
+all: $(EXTENSION__CURRENT_VERSION__FILES)
 endif
 
 ifeq ($(call test, $(MAJORVER), -lt, 130), yes)
@@ -326,7 +326,7 @@ PGXNTOOL_EXTENSIONS = $(basename $(PGXNTOOL_CONTROL_FILES))
 
 # Main target
 # Depend on 'all' to ensure versioned SQL files are generated first
-# Depend on control.mk (which defines EXTENSION_VERSION_FILES)
+# Depend on control.mk (which defines EXTENSION__CURRENT_VERSION__FILES)
 # Depend on control files explicitly so changes trigger rebuilds
 # Generates all supported pg_tle versions for each extension
 .PHONY: pgtle

--- a/control.mk.sh
+++ b/control.mk.sh
@@ -13,7 +13,7 @@
 #   EXTENSION_SQL_FILES += sql/<ext_name>.sql
 #   EXTENSION_<ext_name>_VERSION := <version>
 #   EXTENSION_<ext_name>_VERSION_FILE = sql/<ext_name>--<version>.sql
-#   EXTENSION_VERSION_FILES += $(EXTENSION_<ext_name>_VERSION_FILE)
+#   EXTENSION__CURRENT_VERSION__FILES += $(EXTENSION_<ext_name>_VERSION_FILE)
 #   <rules for generating versioned SQL files>
 #
 # Why control files instead of META.json?
@@ -80,7 +80,7 @@ for control_file in "$@"; do
   echo "EXTENSION_SQL_FILES += sql/${ext}.sql"
   echo "EXTENSION_${ext}_VERSION := ${version}"
   echo "EXTENSION_${ext}_VERSION_FILE	= sql/${ext}--\$(EXTENSION_${ext}_VERSION).sql"
-  echo "EXTENSION_VERSION_FILES		+= \$(EXTENSION_${ext}_VERSION_FILE)"
+  echo "EXTENSION__CURRENT_VERSION__FILES		+= \$(EXTENSION_${ext}_VERSION_FILE)"
   echo "\$(EXTENSION_${ext}_VERSION_FILE): sql/${ext}.sql ${control_file}"
   echo "	@echo '/* DO NOT EDIT - AUTO-GENERATED FILE */' > \$(EXTENSION_${ext}_VERSION_FILE)"
   echo "	@cat sql/${ext}.sql >> \$(EXTENSION_${ext}_VERSION_FILE)"


### PR DESCRIPTION
Fixes #28.

The old name implied it listed every version file for an extension; it actually only ever holds the current/most-recent one per extension. Split out of #61 to keep that PR's scope down.

If your Makefile references `EXTENSION_VERSION_FILES` directly (e.g. to add extra dependencies to `DATA`), update it to `EXTENSION__CURRENT_VERSION__FILES`.

Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/35