### PR TITLE
ci: never check out fork PR head in claude-code-review pull_request_target job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,14 @@ jobs:
   claude-review:
     # Trusted fork only, and skip drafts (don't spend API/CI on unfinished PRs).
     # To add more trusted owners, extend the head-owner check.
+    #
+    # SECURITY-CRITICAL: this owner check is the ONLY thing that makes
+    # `allow-unsafe-pr-checkout: true` below acceptable. Without it, this
+    # pull_request_target job would check out and let Claude act on
+    # arbitrary fork code while holding base-repo secrets/token — a "pwn
+    # request". Do not remove or loosen this condition (e.g. drop the
+    # owner check, or allow non-owner forks) without re-evaluating the
+    # fork-checkout step's safety.
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.owner.login == 'jnasbyupgrade'
@@ -78,12 +86,18 @@ jobs:
         if: steps.gate.outputs.decision == 'run'
         # Intentionally tracks the major-version tag (not a pinned SHA) so
         # upstream fixes are picked up automatically.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           persist-credentials: false
+          # Unsafe by default (actions/checkout refuses fork-PR checkouts
+          # under pull_request_target/workflow_run). Only OK here because
+          # the job is gated to the project owner's forks — see the `if:`
+          # on the `claude-review` job above; that check is what makes
+          # this safe.
+          allow-unsafe-pr-checkout: true
 
       - name: Run Claude Code Review
         if: steps.gate.outputs.decision == 'run'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,8 +9,14 @@ name: Claude Code Review
 # write-capable token. The job is gated to PRs from the trusted `jnasbyupgrade`
 # fork only — an arbitrary external fork can never trigger this secret-bearing
 # job. The workflow file always comes from the base branch (master), so a PR
-# cannot modify the reviewer that runs on it. We check out the PR head only for
-# read context (persist-credentials: false) and never build or execute PR code.
+# cannot modify the reviewer that runs on it. We never check out the fork's PR
+# head: GitHub Actions refuses that combination by default (the "pwn request"
+# guard — see actions/checkout's allow-unsafe-pr-checkout), and
+# anthropics/claude-code-action's own docs (docs/security.md) recommend
+# checking out the base ref and letting the action read PR content via the
+# GitHub API instead. The code-review prompt passes the PR number; the action
+# has a GitHub token and pull-requests read/write, so it fetches the diff
+# itself (e.g. `gh pr diff`) without ever writing fork code to disk.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -23,14 +29,6 @@ jobs:
   claude-review:
     # Trusted fork only, and skip drafts (don't spend API/CI on unfinished PRs).
     # To add more trusted owners, extend the head-owner check.
-    #
-    # SECURITY-CRITICAL: this owner check is the ONLY thing that makes
-    # `allow-unsafe-pr-checkout: true` below acceptable. Without it, this
-    # pull_request_target job would check out and let Claude act on
-    # arbitrary fork code while holding base-repo secrets/token — a "pwn
-    # request". Do not remove or loosen this condition (e.g. drop the
-    # owner check, or allow non-owner forks) without re-evaluating the
-    # fork-checkout step's safety.
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.owner.login == 'jnasbyupgrade'
@@ -82,22 +80,18 @@ jobs:
           echo "decision=$decision" >> "$GITHUB_OUTPUT"
           echo "gate decision: $decision"
 
-      - name: Check out PR head (read-only context)
+      - name: Check out base branch
         if: steps.gate.outputs.decision == 'run'
         # Intentionally tracks the major-version tag (not a pinned SHA) so
         # upstream fixes are picked up automatically.
+        #
+        # No `repository:`/`ref:` here on purpose — this checks out the base
+        # branch (master), never the fork's PR head. See the SECURITY note
+        # above.
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           persist-credentials: false
-          # Unsafe by default (actions/checkout refuses fork-PR checkouts
-          # under pull_request_target/workflow_run). Only OK here because
-          # the job is gated to the project owner's forks — see the `if:`
-          # on the `claude-review` job above; that check is what makes
-          # this safe.
-          allow-unsafe-pr-checkout: true
 
       - name: Run Claude Code Review
         if: steps.gate.outputs.decision == 'run'


### PR DESCRIPTION
`actions/checkout` refuses fork-PR checkouts under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is set explicitly. This broke the `claude-review` job's checkout step deterministically whenever its internal cost gate reached `decision=run` (see the failing run linked from #60: https://github.com/Postgres-Extensions/pgxntool/actions/runs/30218144501/job/89835769849).

Check out the base branch only (drop `repository:`/`ref:`) instead of the fork's head, rather than opting into the unsafe flag. Per `anthropics/claude-code-action`'s own security guidance (`docs/security.md`), this is the preferred pattern for `pull_request_target`: the action reads PR content via its own GitHub token/API (already has `pull-requests` read/write for posting the review) rather than needing the fork's files checked out locally.

This keeps `pull_request_target` (needed for fork PRs to access `CLAUDE_CODE_OAUTH_TOKEN` — plain `pull_request` withholds secrets from fork-triggered runs, per the existing comment in this file). Because `pull_request_target` always runs the workflow file from the base branch, this specific check can't turn green on its own PR — it will only start passing on PRs opened after this merges.

Related pgxntool-test PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/34