### PR TITLE
README.asc: fix stale docs, document undocumented API surface

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -39,15 +39,17 @@ include pgxntool/base.mk
 == make targets
 These are the make targets that are provided by base.mk
 
-NOTE: all the targets normally provided by Postgres http://www.postgresql.org/docs/current/static/extend-pgxs.html[PGXS] still work.
+NOTE: all the targets normally provided by Postgres http://www.postgresql.org/docs/current/static/extend-pgxs.html[PGXS] still work. If you need to skip PGXS being included entirely (for advanced/non-standard setups), set `PGXNTOOL_NO_PGXS_INCLUDE` in your Makefile before `include pgxntool/base.mk`.
 
 === html
 This will build any .html files that can be created. See <<_Document_Handling>>.
 
 === test
-Runs unit tests via the PGXS `installcheck` target. Unlike a simple `make installcheck` though, the `test` rule has the following prerequisites: clean testdeps install installcheck. All of those are PGXS rules, except for `testdeps`.
+Runs unit tests via the PGXS `installcheck` target. Unlike a simple `make installcheck` though, the `test` rule has the following prerequisites: `testdeps install installcheck` (plus `test-build`, if enabled — see <<_test_build>>). All of those are PGXS rules, except for `testdeps` and `test-build`.
 
-NOTE: While you can still run `make installcheck` or any other valid PGXS make target directly, it's recommended to use `make test` when using pgxntool. The `test` target ensures clean builds, proper test isolation, and correct dependency installation.
+NOTE: `test` intentionally does *not* depend on `clean` — that caused problems with incremental/watch-based builds. If your tests need a clean build to pass, that's a sign of a missing dependency elsewhere rather than something to fix by adding `clean` back.
+
+NOTE: While you can still run `make installcheck` or any other valid PGXS make target directly, it's recommended to use `make test` when using pgxntool. The `test` target ensures proper test isolation and correct dependency installation.
 
 === test-build
 Validates that extension SQL files are syntactically correct before running the full test suite. This feature runs SQL files from `test/build/` through `pg_regress`, providing better error messages than `CREATE EXTENSION` failures when there are syntax errors in your extension code.
@@ -227,15 +229,20 @@ IMPORTANT: *`make results` requires manual verification first*. The correct work
 Never run `make results` without first verifying the test changes are correct. The `results` target copies files from `test/results/` to `test/expected/`, so running it blindly will make incorrect output become the new expected behavior.
 
 ==== verify-results safeguard
-By default, `make results` will refuse to run if `test/results/regression.diffs` exists (indicating failing tests). This prevents accidentally updating expected files with incorrect output.
+By default, `make results` will refuse to run if your tests are failing, so you can't accidentally promote incorrect output into the new expected results. Which failures it looks for is controlled by `PGXNTOOL_VERIFY_RESULTS_MODE`:
 
-If tests are failing, you'll see:
+`pgtap` (the default):: Scans `test/results/*.out` for pgTAP `not ok` lines (ignoring `# TODO` items) and plan-count mismatches, then also checks `test/results/regression.diffs` for any output mismatch pgTAP itself wouldn't catch.
+`diffs`:: Only checks whether `test/results/regression.diffs` exists.
+
+If tests are failing, `make results` prints an explanation of what failed and exits without touching `test/expected/`; fix the failures, then re-run `make results`.
+
+To select a mode explicitly:
 ----
-ERROR: Tests are failing. Cannot run 'make results'.
-Fix test failures first, then run 'make results'.
+# In your Makefile
+PGXNTOOL_VERIFY_RESULTS_MODE = diffs  # or pgtap (the default)
 ----
 
-To disable this safeguard (not recommended):
+To disable this safeguard entirely (not recommended):
 ----
 # In your Makefile
 PGXNTOOL_ENABLE_VERIFY_RESULTS = no
@@ -245,9 +252,9 @@ make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results
 ----
 
 === tag
-`make tag` will create an annotated git tag for the current version of your extension, as determined by the META.json file (generated from `META.in.json` — see <<_pgxn_distributions_vs_extensions>>), and push it to `origin`. The reason to do this is so you can always refer to the exact code that went into a released version.
+`make tag` will create a git tag for the current version of your extension, as determined by the META.json file (generated from `META.in.json` — see <<_pgxn_distributions_vs_extensions>>), and push it to `origin`. The reason to do this is so you can always refer to the exact code that went into a released version.
 
-If there's already a tag for the current version that probably means you forgot to update META.json, so you'll get an error. If you're certain you want to over-write the tag, you can do `make forcetag`, which removes the existing tag (via `make rmtag`) and creates a new one.
+If a tag for the current version already exists and points at your current commit, `make tag` does nothing — this makes it safe for other targets (like `dist`) to depend on `tag` without worrying about re-running it. If the existing tag points at a *different* commit — meaning you likely forgot to bump the version — you'll get an error. If you're certain you want to over-write the tag, you can do `make forcetag`, which removes the existing tag (via `make rmtag`) and creates a new one.
 
 WARNING: You will be very unhappy if you forget to update the .control file for your extension! There is an https://github.com/decibel/pgxntool/issues/1[open issue] to improve this.
 
@@ -255,6 +262,10 @@ WARNING: You will be very unhappy if you forget to update the .control file for 
 `make dist` will create a .zip file for your current version that you can upload to PGXN. It first runs `tag` (creating/pushing the version's git tag as described above if needed), then uses `git archive` at that tag to build the .zip file, so the archive always matches the exact tagged commit. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json, generated from `META.in.json`). The .zip file is placed in the *parent* directory so as not to clutter up your git repo.
 
 NOTE: Part of the `clean` recipe is cleaning up these .zip files. If you accidentally clean before uploading, just run `make dist-only`.
+
+WARNING: If your project has a `.gitattributes` file, `make dist`/`make dist-only` will refuse to run unless it's committed to git, and will tell you so. This is because `git archive` (which builds the .zip) only honors `export-ignore` attributes on *committed* files — an uncommitted `.gitattributes` would silently have no effect on the archive contents, which could leak files into your PGXN distribution that you meant to exclude.
+
+`make forcedist` is a shortcut for `forcetag dist`: it force-recreates the tag (see `forcetag` above) before rebuilding the distribution .zip.
 
 === pgxntool-sync
 This rule will pull down the latest released version of PGXNtool via `git subtree pull` and then reconcile the files `setup.sh` copied into your project (`.gitignore`, `test/deps.sql`) with a 3-way merge.
@@ -264,6 +275,12 @@ NOTE: Your repository must be clean (no modified files) in order to run this. Ru
 TIP: The actual work is done by `pgxntool/pgxntool-sync.sh`, so you can run it directly (`pgxntool/pgxntool-sync.sh`) if you'd rather not go through `make`. It optionally takes `<repo>` and `<ref>` arguments to pull from somewhere other than the default.
 
 TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things. `make pgxntool-sync-<name>` pulls from the `<repo> <ref>` defined by the `pgxntool-sync-<name>` make variable.
+
+=== list
+`make list` prints every make target defined in your project — including ones provided by PGXS and pgxntool, not just ones you wrote — one per line. Useful for discovering what's available without reading through the Makefile.
+
+=== print-%
+`make print-VARNAME` prints the current value (and origin) of any make variable, e.g. `make print-PGXNVERSION`. Useful for debugging why a variable isn't set to what you expect.
 
 === distclean
 `make distclean` removes generated configuration files (`META.json` — generated from `META.in.json` — plus `meta.mk` and `control.mk`) that survive a normal `make clean`.
@@ -293,7 +310,7 @@ make check-pgtle
 
 === run-pgtle
 Registers all extensions with pg_tle by executing the generated pg_tle registration SQL files in a PostgreSQL database. This target:
-- Requires pg_tle extension to be installed (checked via `check-pgtle`)
+- Requires pg_tle to be installed in the target database. This isn't a make-level dependency on `check-pgtle` — `pgtle.sh` checks it itself when it runs, and will tell you to run `make check-pgtle` if pg_tle isn't there
 - Uses `pgtle.sh` to determine which version range directory to use based on the installed pg_tle version
 - Runs all generated SQL files via `psql` to register your extensions with pg_tle
 
@@ -459,9 +476,8 @@ PGXNtool replaces each `$(ASCIIDOC_EXTS)` in `$(ASCIIDOC_FILES)` with `html`.
 The result is appended to `ASCIIDOC_HTML` using `+=`.
 
 === Document Rules
-If Asciidoc is found (or `$(ASCIIDOC)` is set), the `html` rule will be added as a prerequisite to the `install` and `installchec` rules.
-That will ensure that docs are generated for install and test, but only if Asciidoc is available.
-The `dist` rule will always depend on `html` though, to ensure html files are up-to-date before creating a distribution.
+If Asciidoc is found (or `$(ASCIIDOC)` is set), `html` is added as a dependency of the `all` target, which both `install` and `installcheck` depend on — so docs get built for install and test, but only if Asciidoc is available.
+The `dist` rule always depends on `html` directly, regardless of whether Asciidoc was found, to ensure html files are up-to-date before creating a distribution.
 
 The `html` rule simply depends on `$(ASCIIDOC_HTML).
 This rule is always present.
@@ -474,11 +490,11 @@ These rules are generated from `ASCIIDOC_template`:
 ----
 define ASCIIDOC_template
 %.html: %.$(1) # <1>
-ifndef ASCIIDOC
+ifeq (,$(strip $(ASCIIDOC)))
 	$$(warning Could not find "asciidoc" or "asciidoctor". Add one of them to your PATH,)
 	$$(warning or set ASCIIDOC to the correct location.)
 	$$(error Could not build %$$@)
-endif # ifndef ASCIIDOC
+endif # ifeq ASCIIDOC
 	$$(ASCIIDOC) $$(ASCIIDOC_FLAGS) $$<
 endef # define ASCIIDOC_template
 ----
@@ -487,6 +503,8 @@ endef # define ASCIIDOC_template
 These rules will *always* exist, even if `$(ASCIIDOC)` isn't set (ie: if Asciidoc wasn't found on the system).
 These rules will throw an error if they are run if `$(ASCIIDOC)` isn't defined.
 On a normal user system that should never happen, because the `html` rule won't be included in `install` or `installcheck`.
+
+`make docclean` removes all generated HTML files (`$(DOCS_HTML)`). It's separate from `make clean`/`make distclean`, so you can clear out generated docs without touching your build artifacts.
 
 === The DOCS variable
 This variable has special meaning to PGXS.
@@ -564,6 +582,15 @@ myproject/
         ├── ext1.sql
         └── ext2.sql
 ----
+
+==== Direct pgtle.sh Invocation
+
+`pgtle`, `check-pgtle`, and `run-pgtle` are thin make wrappers around `pgxntool/pgtle.sh`. For more targeted operations you can run it directly:
+
+- `pgtle.sh --extension NAME [--pgtle-version VERSION]` — generate registration SQL for one extension (what `make pgtle` wraps).
+- `pgtle.sh --get-version` — print the pg_tle version installed in the target database (empty if not installed).
+- `pgtle.sh --get-dir VERSION` — print which version-range directory (see <<_version_groupings>>) a given pg_tle version maps to, without generating anything.
+- `pgtle.sh --run` — execute the generated registration SQL against the target database (what `make run-pgtle` wraps).
 
 === How It Works
 `make pgtle` does the following:

--- a/README.asc
+++ b/README.asc
@@ -594,7 +594,7 @@ myproject/
 
 ==== Direct pgtle.sh Invocation
 
-`pgtle`, `check-pgtle`, and `run-pgtle` are thin make wrappers around `pgxntool/pgtle.sh`. For more targeted operations you can run it directly:
+`pgtle`, `check-pgtle`, and `run-pgtle` are thin make wrappers around `pgtle.sh`. For more targeted operations you can run it directly:
 
 - `pgtle.sh --extension NAME [--pgtle-version VERSION]` — generate registration SQL for one extension (what `make pgtle` wraps).
 - `pgtle.sh --get-version` — print the pg_tle version installed in the target database (empty if not installed).

--- a/README.asc
+++ b/README.asc
@@ -272,6 +272,8 @@ This rule will pull down the latest released version of PGXNtool via `git subtre
 
 NOTE: Your repository must be clean (no modified files) in order to run this. Running this command will produce a git commit of the merge.
 
+NOTE: `git subtree pull` copies pgxntool's entire tree into your project, including dev-only directories (`pgxntool/.github`, `pgxntool/.claude`) that don't belong in a project that merely embeds pgxntool. Every sync automatically removes these two directories from `pgxntool/` afterward — this is expected, not a bug, and doesn't affect anything else in your project.
+
 TIP: The actual work is done by `pgxntool/pgxntool-sync.sh`, so you can run it directly (`pgxntool/pgxntool-sync.sh`) if you'd rather not go through `make`. It optionally takes `<repo>` and `<ref>` arguments to pull from somewhere other than the default.
 
 TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things. `make pgxntool-sync-<name>` pulls from the `<repo> <ref>` defined by the `pgxntool-sync-<name>` make variable.

--- a/README.asc
+++ b/README.asc
@@ -45,7 +45,9 @@ NOTE: all the targets normally provided by Postgres http://www.postgresql.org/do
 This will build any .html files that can be created. See <<_Document_Handling>>.
 
 === test
-Runs unit tests via the PGXS `installcheck` target. Unlike a simple `make installcheck` though, the `test` rule has the following prerequisites: `testdeps install installcheck` (plus `test-build`, if enabled — see <<_test_build>>). All of those are PGXS rules, except for `testdeps` and `test-build`.
+Runs your extension's test suite: installs the extension and runs it through PGXS's `installcheck`, first pulling in anything you've hooked into <<_testdeps>> and, if enabled, sanity-checking your test SQL via <<_test_build>>.
+
+Whether `test-build` runs is controlled by the `PGXNTOOL_ENABLE_TEST_BUILD` variable — see <<_test_build>> for what it does and how to turn it on/off.
 
 NOTE: `test` intentionally does *not* depend on `clean` — that caused problems with incremental/watch-based builds. If your tests need a clean build to pass, that's a sign of a missing dependency elsewhere rather than something to fix by adding `clean` back.
 

--- a/README.html
+++ b/README.html
@@ -1701,7 +1701,7 @@ This is only a basic example. Always refer to the <a href="https://github.com/aw
 <div class="sect3">
 <h4 id="_direct_pgtle_sh_invocation"><a class="anchor" href="#_direct_pgtle_sh_invocation"></a><a class="link" href="#_direct_pgtle_sh_invocation">7.5.2. Direct pgtle.sh Invocation</a></h4>
 <div class="paragraph">
-<p><code>pgtle</code>, <code>check-pgtle</code>, and <code>run-pgtle</code> are thin make wrappers around <code>pgxntool/pgtle.sh</code>. For more targeted operations you can run it directly:</p>
+<p><code>pgtle</code>, <code>check-pgtle</code>, and <code>run-pgtle</code> are thin make wrappers around <code>pgtle.sh</code>. For more targeted operations you can run it directly:</p>
 </div>
 <div class="ulist">
 <ul>
@@ -1928,7 +1928,7 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-29 13:24:38 -0500
+Last updated 2026-07-29 13:41:25 -0500
 </div>
 </div>
 </body>

--- a/README.html
+++ b/README.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.23">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <meta name="author" content="Easier PGXN development">
 <title>PGXNtool</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
@@ -141,7 +141,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -163,7 +163,6 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
-body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -329,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -458,20 +457,23 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_tag">4.7. tag</a></li>
 <li><a href="#_dist">4.8. dist</a></li>
 <li><a href="#_pgxntool_sync">4.9. pgxntool-sync</a></li>
-<li><a href="#_distclean">4.10. distclean</a></li>
-<li><a href="#_pgtle">4.11. pgtle</a></li>
-<li><a href="#_check_pgtle">4.12. check-pgtle</a></li>
-<li><a href="#_run_pgtle">4.13. run-pgtle</a></li>
+<li><a href="#_list">4.10. list</a></li>
+<li><a href="#_print">4.11. print-%</a></li>
+<li><a href="#_distclean">4.12. distclean</a></li>
+<li><a href="#_pgtle">4.13. pgtle</a></li>
+<li><a href="#_check_pgtle">4.14. check-pgtle</a></li>
+<li><a href="#_run_pgtle">4.15. run-pgtle</a></li>
 </ul>
 </li>
 <li><a href="#_version_specific_sql_files">5. Version-Specific SQL Files</a>
 <ul class="sectlevel2">
-<li><a href="#_how_version_files_are_generated">5.1. How Version Files Are Generated</a></li>
-<li><a href="#_what_controls_the_version_number">5.2. What Controls the Version Number</a></li>
-<li><a href="#_committing_version_files">5.3. Committing Version Files</a></li>
-<li><a href="#_alternative_ignoring_version_files">5.4. Alternative: Ignoring Version Files</a></li>
-<li><a href="#_distribution_inclusion">5.5. Distribution Inclusion</a></li>
-<li><a href="#_multiple_versions">5.6. Multiple Versions</a></li>
+<li><a href="#_pgxn_distributions_vs_extensions">5.1. PGXN Distributions vs. Extensions</a></li>
+<li><a href="#_how_version_files_are_generated">5.2. How Version Files Are Generated</a></li>
+<li><a href="#_what_controls_the_version_number">5.3. What Controls the Version Number</a></li>
+<li><a href="#_committing_version_files">5.4. Committing Version Files</a></li>
+<li><a href="#_alternative_ignoring_all_version_files">5.5. Alternative: Ignoring All Version Files</a></li>
+<li><a href="#_distribution_inclusion">5.6. Distribution Inclusion</a></li>
+<li><a href="#_multiple_versions">5.7. Multiple Versions</a></li>
 </ul>
 </li>
 <li><a href="#_document_handling">6. Document Handling</a>
@@ -502,7 +504,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>PGXNtool is meant to make developing new Postgres extensions for <a href="http://pgxn.org">PGXN</a> easier.</p>
 </div>
 <div class="paragraph">
-<p>Currently, it consists a base Makefile that you can include instead of writing your own, a template META.json, and some test framework. More features will be added over time.</p>
+<p>Currently, it consists a base Makefile that you can include instead of writing your own, a template <code>META.in.json</code> (from which <code>META.json</code> is generated — you edit the former, never the latter directly), and some test framework. More features will be added over time.</p>
 </div>
 <div class="paragraph">
 <p>If you find any bugs or have ideas for improvements, please <a href="https://github.com/decibel/pgxntool/issues"><strong>open an issue</strong></a>.</p>
@@ -575,7 +577,7 @@ pgxntool/setup.sh</pre>
 <div class="title">Note</div>
 </td>
 <td class="content">
-all the targets normally provided by Postgres <a href="http://www.postgresql.org/docs/current/static/extend-pgxs.html">PGXS</a> still work.
+all the targets normally provided by Postgres <a href="http://www.postgresql.org/docs/current/static/extend-pgxs.html">PGXS</a> still work. If you need to skip PGXS being included entirely (for advanced/non-standard setups), set <code>PGXNTOOL_NO_PGXS_INCLUDE</code> in your Makefile before <code>include pgxntool/base.mk</code>.
 </td>
 </tr>
 </table>
@@ -589,7 +591,10 @@ all the targets normally provided by Postgres <a href="http://www.postgresql.org
 <div class="sect2">
 <h3 id="_test"><a class="anchor" href="#_test"></a><a class="link" href="#_test">4.2. test</a></h3>
 <div class="paragraph">
-<p>Runs unit tests via the PGXS <code>installcheck</code> target. Unlike a simple <code>make installcheck</code> though, the <code>test</code> rule has the following prerequisites: clean testdeps install installcheck. All of those are PGXS rules, except for <code>testdeps</code>.</p>
+<p>Runs your extension&#8217;s test suite: installs the extension and runs it through PGXS&#8217;s <code>installcheck</code>, first pulling in anything you&#8217;ve hooked into <a href="#_testdeps">testdeps</a> and, if enabled, sanity-checking your test SQL via <a href="#_test_build">test-build</a>.</p>
+</div>
+<div class="paragraph">
+<p>Whether <code>test-build</code> runs is controlled by the <code>PGXNTOOL_ENABLE_TEST_BUILD</code> variable — see <a href="#_test_build">test-build</a> for what it does and how to turn it on/off.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -598,7 +603,19 @@ all the targets normally provided by Postgres <a href="http://www.postgresql.org
 <div class="title">Note</div>
 </td>
 <td class="content">
-While you can still run <code>make installcheck</code> or any other valid PGXS make target directly, it&#8217;s recommended to use <code>make test</code> when using pgxntool. The <code>test</code> target ensures clean builds, proper test isolation, and correct dependency installation.
+<code>test</code> intentionally does <strong>not</strong> depend on <code>clean</code> — that caused problems with incremental/watch-based builds. If your tests need a clean build to pass, that&#8217;s a sign of a missing dependency elsewhere rather than something to fix by adding <code>clean</code> back.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+While you can still run <code>make installcheck</code> or any other valid PGXS make target directly, it&#8217;s recommended to use <code>make test</code> when using pgxntool. The <code>test</code> target ensures proper test isolation and correct dependency installation.
 </td>
 </tr>
 </table>
@@ -786,6 +803,81 @@ PGXNTOOL_ENABLE_TEST_INSTALL = yes  # or no</pre>
 <div class="paragraph">
 <p><strong>Key detail:</strong> Install files and regular tests run in a single <code>pg_regress</code> invocation. This means the database is NOT dropped between install and test phases — state created by install files persists into the main test suite.</p>
 </div>
+<div class="sect3">
+<h4 id="_update_upgrade_uu_testing"><a class="anchor" href="#_update_upgrade_uu_testing"></a><a class="link" href="#_update_upgrade_uu_testing">4.4.1. Update &amp; Upgrade (U&amp;U) Testing</a></h4>
+<div class="paragraph">
+<p>Beyond validating a plain install, it&#8217;s worth testing that your extension behaves correctly across the two transitions every extension with more than one release eventually goes through:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>Update</strong>: <code>ALTER EXTENSION ext UPDATE</code>, moving to a newer extension version on the same PostgreSQL version.</p>
+</li>
+<li>
+<p><strong>Upgrade</strong>: <code>pg_upgrade</code>, moving to a newer PostgreSQL major version while carrying the extension&#8217;s on-disk catalog state along with it.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Both catch bugs that a simple "did the script run without error" check misses — wrong mappings, missing `REVOKE`s, objects that drifted from the base SQL, or catalog state that doesn&#8217;t survive a binary upgrade cleanly. This isn&#8217;t a niche concern that only applies if your extension does something unusual (adds enum types, custom operators, etc.) — it applies to any extension that will ever be updated or upgraded in place, which in practice is every extension.</p>
+</div>
+<div class="paragraph">
+<p><code>test/install</code> is the recommended place to build this, because its "load once, committed, before the suite" mechanic (described above) is exactly what update/upgrade testing needs.</p>
+</div>
+<div class="paragraph">
+<p><strong>The pattern</strong>: load the extension exactly once, committed, from a <code>test/install/*.sql</code> file, in one of several modes selected by a custom backend setting that your <code>Makefile</code> sets via <code>PGOPTIONS</code> (e.g. <code>-c myext.test_load_mode=$(TEST_LOAD_SOURCE)</code>) and that <code>test/install</code> reads with <code>current_setting('myext.test_load_mode')</code>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>fresh</strong>: <code>CREATE EXTENSION ext;</code></p>
+</li>
+<li>
+<p><strong>update</strong>: <code>CREATE EXTENSION ext VERSION 'oldest_supported';</code> then <code>ALTER EXTENSION ext UPDATE;</code> (to the current <code>default_version</code>, or an explicit intermediate version)</p>
+</li>
+<li>
+<p><strong>existing</strong>: the extension is already installed — by a real <code>pg_upgrade</code>, or an update performed outside the suite — and <code>test/install</code> only asserts it&#8217;s present at the expected version, without dropping or touching it</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The <strong>same</strong> <code>test/sql/<strong></code> suite and the *same</strong> <code>test/expected/<strong></code> output then run unchanged against every mode. Identical expected output passing in *update</strong> mode <strong>is</strong> the update-equivalence assertion — if the updated database behaves any differently than a fresh install, some test will diff. Running that same suite in <strong>existing</strong> mode against a database that just went through a real <code>pg_upgrade</code> gives you upgrade testing using the same test files, no separate suite required.</p>
+</div>
+<div class="paragraph">
+<p>If you adopt this pattern, <code>test/deps.sql</code> should no longer run <code>CREATE EXTENSION</code> itself for the per-test setup — the committed install performed by <code>test/install</code> persists into every (rolled-back) test file, exactly as described above.</p>
+</div>
+<div class="paragraph">
+<p><strong>Why the install step must be committed, not run per-test in <code>test/deps.sql</code>:</strong> every <code>test/sql/</code> file runs inside <code>BEGIN; &#8230;&#8203; ROLLBACK;</code> — a pgxntool convention (<code>test/pgxntool/setup.sql</code> opens the transaction; since it&#8217;s never committed, it rolls back when the session ends). Running the update inside that transaction means the suite never actually exercises a <strong>committed</strong> update — which doesn&#8217;t match production, where <code>ALTER EXTENSION UPDATE</code> commits before anything else touches the database, and it hides bugs that only show up once the update is durably committed. (Modifying an <code>enum</code> is one example of how this can turn into an outright failure rather than just a hidden bug — but it&#8217;s just an example; the reason to commit first holds regardless of what the update script does.)</p>
+</div>
+<div class="paragraph">
+<p>As a bonus, sharing one committed install across every test file also removes the per-test re-install cost.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+This pattern isn&#8217;t (yet) native to pgxntool — you wire up the mode selection and <code>PGOPTIONS</code> plumbing yourself in <code>test/install</code> and your <code>Makefile</code>. First-class support (a standard mode-switching toggle, and scaffolding for real <code>pg_upgrade</code> testing) is planned; see <a href="https://github.com/Postgres-Extensions/pgxntool/issues/42">issue #42</a>.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Working examples</strong> (specific files, not full PRs — both extensions' histories include plenty of unrelated changes):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/Postgres-Extensions/cat_tools/blob/d01c933a3fcbf28d3bdd2bf6f2bd7b116e95e604/test/install/load.sql">cat_tools <code>test/install/load.sql</code></a> and the <code>TEST_LOAD_SOURCE</code> block in its <a href="https://github.com/Postgres-Extensions/cat_tools/blob/d01c933a3fcbf28d3bdd2bf6f2bd7b116e95e604/Makefile"><code>Makefile</code></a> — the fresh/update/existing pattern above, including the <code>PGOPTIONS</code> wiring. This is a reasonably complete example, and somewhat more elaborate than the minimum needed to get started.</p>
+</li>
+<li>
+<p><a href="https://github.com/Postgres-Extensions/pg_count_nulls/blob/9f088ac36f6345023bb5b3d20ad0e4aa6ade0d69/test/sql/extension_tests.sql">pg_count_nulls <code>test/sql/extension_tests.sql</code></a> additionally demonstrates testing an extension installed into a non-default schema. It&#8217;s a useful reference for that specific problem, but it also defines its assertions as plpgsql functions rather than plain pgTAP calls — a pattern that adds complexity of its own and isn&#8217;t recommended as a model for U&amp;U testing itself.</p>
+</li>
+</ul>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_testdeps"><a class="anchor" href="#_testdeps"></a><a class="link" href="#_testdeps">4.5. testdeps</a></h3>
@@ -862,19 +954,34 @@ It will probably cause problems if you try to create a <code>testdeps</code> rul
 <div class="sect3">
 <h4 id="_verify_results_safeguard"><a class="anchor" href="#_verify_results_safeguard"></a><a class="link" href="#_verify_results_safeguard">4.6.1. verify-results safeguard</a></h4>
 <div class="paragraph">
-<p>By default, <code>make results</code> will refuse to run if <code>test/results/regression.diffs</code> exists (indicating failing tests). This prevents accidentally updating expected files with incorrect output.</p>
+<p>By default, <code>make results</code> will refuse to run if your tests are failing, so you can&#8217;t accidentally promote incorrect output into the new expected results. Which failures it looks for is controlled by <code>PGXNTOOL_VERIFY_RESULTS_MODE</code>:</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>pgtap</code> (the default)</dt>
+<dd>
+<p>Scans <code>test/results/*.out</code> for pgTAP <code>not ok</code> lines (ignoring <code># TODO</code> items) and plan-count mismatches, then also checks <code>test/results/regression.diffs</code> for any output mismatch pgTAP itself wouldn&#8217;t catch.</p>
+</dd>
+<dt class="hdlist1"><code>diffs</code></dt>
+<dd>
+<p>Only checks whether <code>test/results/regression.diffs</code> exists.</p>
+</dd>
+</dl>
 </div>
 <div class="paragraph">
-<p>If tests are failing, you&#8217;ll see:</p>
+<p>If tests are failing, <code>make results</code> prints an explanation of what failed and exits without touching <code>test/expected/</code>; fix the failures, then re-run <code>make results</code>.</p>
+</div>
+<div class="paragraph">
+<p>To select a mode explicitly:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>ERROR: Tests are failing. Cannot run 'make results'.
-Fix test failures first, then run 'make results'.</pre>
+<pre># In your Makefile
+PGXNTOOL_VERIFY_RESULTS_MODE = diffs  # or pgtap (the default)</pre>
 </div>
 </div>
 <div class="paragraph">
-<p>To disable this safeguard (not recommended):</p>
+<p>To disable this safeguard entirely (not recommended):</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -890,10 +997,10 @@ make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results</pre>
 <div class="sect2">
 <h3 id="_tag"><a class="anchor" href="#_tag"></a><a class="link" href="#_tag">4.7. tag</a></h3>
 <div class="paragraph">
-<p><code>make tag</code> will create a git branch for the current version of your extension, as determined by the META.json file. The reason to do this is so you can always refer to the exact code that went into a released version.</p>
+<p><code>make tag</code> will create a git tag for the current version of your extension, as determined by the META.json file (generated from <code>META.in.json</code> — see <a href="#_pgxn_distributions_vs_extensions">PGXN Distributions vs. Extensions</a>), and push it to <code>origin</code>. The reason to do this is so you can always refer to the exact code that went into a released version.</p>
 </div>
 <div class="paragraph">
-<p>If there&#8217;s already a tag for the current version that probably means you forgot to update META.json, so you&#8217;ll get an error. If you&#8217;re certain you want to over-write the tag, you can do <code>make forcetag</code>, which removes the existing tag (via <code>make rmtag</code>) and creates a new one.</p>
+<p>If a tag for the current version already exists and points at your current commit, <code>make tag</code> does nothing — this makes it safe for other targets (like <code>dist</code>) to depend on <code>tag</code> without worrying about re-running it. If the existing tag points at a <strong>different</strong> commit — meaning you likely forgot to bump the version — you&#8217;ll get an error. If you&#8217;re certain you want to over-write the tag, you can do <code>make forcetag</code>, which removes the existing tag (via <code>make rmtag</code>) and creates a new one.</p>
 </div>
 <div class="admonitionblock warning">
 <table>
@@ -911,7 +1018,7 @@ You will be very unhappy if you forget to update the .control file for your exte
 <div class="sect2">
 <h3 id="_dist"><a class="anchor" href="#_dist"></a><a class="link" href="#_dist">4.8. dist</a></h3>
 <div class="paragraph">
-<p><code>make dist</code> will create a .zip file for your current version that you can upload to PGXN. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json). The .zip file is placed in the <strong>parent</strong> directory so as not to clutter up your git repo.</p>
+<p><code>make dist</code> will create a .zip file for your current version that you can upload to PGXN. It first runs <code>tag</code> (creating/pushing the version&#8217;s git tag as described above if needed), then uses <code>git archive</code> at that tag to build the .zip file, so the archive always matches the exact tagged commit. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json, generated from <code>META.in.json</code>). The .zip file is placed in the <strong>parent</strong> directory so as not to clutter up your git repo.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -924,6 +1031,21 @@ Part of the <code>clean</code> recipe is cleaning up these .zip files. If you ac
 </td>
 </tr>
 </table>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Warning</div>
+</td>
+<td class="content">
+If your project has a <code>.gitattributes</code> file, <code>make dist</code>/<code>make dist-only</code> will refuse to run unless it&#8217;s committed to git, and will tell you so. This is because <code>git archive</code> (which builds the .zip) only honors <code>export-ignore</code> attributes on <strong>committed</strong> files — an uncommitted <code>.gitattributes</code> would silently have no effect on the archive contents, which could leak files into your PGXN distribution that you meant to exclude.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><code>make forcedist</code> is a shortcut for <code>forcetag dist</code>: it force-recreates the tag (see <code>forcetag</code> above) before rebuilding the distribution .zip.</p>
 </div>
 </div>
 <div class="sect2">
@@ -939,6 +1061,18 @@ Part of the <code>clean</code> recipe is cleaning up these .zip files. If you ac
 </td>
 <td class="content">
 Your repository must be clean (no modified files) in order to run this. Running this command will produce a git commit of the merge.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<code>git subtree pull</code> copies pgxntool&#8217;s entire tree into your project, including dev-only directories (<code>pgxntool/.github</code>, <code>pgxntool/.claude</code>) that don&#8217;t belong in a project that merely embeds pgxntool. Every sync automatically removes these two directories from <code>pgxntool/</code> afterward — this is expected, not a bug, and doesn&#8217;t affect anything else in your project.
 </td>
 </tr>
 </table>
@@ -969,9 +1103,21 @@ There is also a <code>pgxntool-sync-%</code> rule if you need to do more advance
 </div>
 </div>
 <div class="sect2">
-<h3 id="_distclean"><a class="anchor" href="#_distclean"></a><a class="link" href="#_distclean">4.10. distclean</a></h3>
+<h3 id="_list"><a class="anchor" href="#_list"></a><a class="link" href="#_list">4.10. list</a></h3>
 <div class="paragraph">
-<p><code>make distclean</code> removes generated configuration files (<code>META.json</code>, <code>meta.mk</code>, <code>control.mk</code>) that survive a normal <code>make clean</code>.</p>
+<p><code>make list</code> prints every make target defined in your project — including ones provided by PGXS and pgxntool, not just ones you wrote — one per line. Useful for discovering what&#8217;s available without reading through the Makefile.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_print"><a class="anchor" href="#_print"></a><a class="link" href="#_print">4.11. print-%</a></h3>
+<div class="paragraph">
+<p><code>make print-VARNAME</code> prints the current value (and origin) of any make variable, e.g. <code>make print-PGXNVERSION</code>. Useful for debugging why a variable isn&#8217;t set to what you expect.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_distclean"><a class="anchor" href="#_distclean"></a><a class="link" href="#_distclean">4.12. distclean</a></h3>
+<div class="paragraph">
+<p><code>make distclean</code> removes generated configuration files (<code>META.json</code> — generated from <code>META.in.json</code> — plus <code>meta.mk</code> and <code>control.mk</code>) that survive a normal <code>make clean</code>.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -995,7 +1141,7 @@ PGXS doesn&#8217;t provide any special support for <code>distclean</code> — it
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgtle"><a class="anchor" href="#_pgtle"></a><a class="link" href="#_pgtle">4.11. pgtle</a></h3>
+<h3 id="_pgtle"><a class="anchor" href="#_pgtle"></a><a class="link" href="#_pgtle">4.13. pgtle</a></h3>
 <div class="paragraph">
 <p>Generates pg_tle (Trusted Language Extensions) registration SQL files for deploying extensions in managed environments like AWS RDS/Aurora. See <a href="#_pg_tle_Support">[_pg_tle_Support]</a> for complete documentation.</p>
 </div>
@@ -1004,7 +1150,7 @@ PGXS doesn&#8217;t provide any special support for <code>distclean</code> — it
 </div>
 </div>
 <div class="sect2">
-<h3 id="_check_pgtle"><a class="anchor" href="#_check_pgtle"></a><a class="link" href="#_check_pgtle">4.12. check-pgtle</a></h3>
+<h3 id="_check_pgtle"><a class="anchor" href="#_check_pgtle"></a><a class="link" href="#_check_pgtle">4.14. check-pgtle</a></h3>
 <div class="paragraph">
 <p>Checks if pg_tle is installed and reports the version. This target:
 - Reports the version from <code>pg_extension</code> if <code>CREATE EXTENSION pg_tle</code> has been run in the database
@@ -1020,10 +1166,10 @@ PGXS doesn&#8217;t provide any special support for <code>distclean</code> — it
 </div>
 </div>
 <div class="sect2">
-<h3 id="_run_pgtle"><a class="anchor" href="#_run_pgtle"></a><a class="link" href="#_run_pgtle">4.13. run-pgtle</a></h3>
+<h3 id="_run_pgtle"><a class="anchor" href="#_run_pgtle"></a><a class="link" href="#_run_pgtle">4.15. run-pgtle</a></h3>
 <div class="paragraph">
 <p>Registers all extensions with pg_tle by executing the generated pg_tle registration SQL files in a PostgreSQL database. This target:
-- Requires pg_tle extension to be installed (checked via <code>check-pgtle</code>)
+- Requires pg_tle to be installed in the target database. This isn&#8217;t a make-level dependency on <code>check-pgtle</code> — <code>pgtle.sh</code> checks it itself when it runs, and will tell you to run <code>make check-pgtle</code> if pg_tle isn&#8217;t there
 - Uses <code>pgtle.sh</code> to determine which version range directory to use based on the installed pg_tle version
 - Runs all generated SQL files via <code>psql</code> to register your extensions with pg_tle</p>
 </div>
@@ -1065,14 +1211,36 @@ The <code>pgtle</code> target is a dependency, so <code>make run-pgtle</code> wi
 <p>PGXNtool automatically generates version-specific SQL files from your base SQL file. These files follow the pattern <code>sql/{extension}--{version}.sql</code> and are used by PostgreSQL&#8217;s extension system to install specific versions of your extension.</p>
 </div>
 <div class="sect2">
-<h3 id="_how_version_files_are_generated"><a class="anchor" href="#_how_version_files_are_generated"></a><a class="link" href="#_how_version_files_are_generated">5.1. How Version Files Are Generated</a></h3>
+<h3 id="_pgxn_distributions_vs_extensions"><a class="anchor" href="#_pgxn_distributions_vs_extensions"></a><a class="link" href="#_pgxn_distributions_vs_extensions">5.1. PGXN Distributions vs. Extensions</a></h3>
+<div class="paragraph">
+<p>PGXN distinguishes two things it&#8217;s easy to conflate: a <strong>distribution</strong> and an <strong>extension</strong>. Per <a href="https://pgxn.org/spec/">the PGXN meta spec</a>, a distribution is "a collection of extensions, source code, utilities, tests, and/or documents that are distributed together" — the thing you release and upload to PGXN, identified by the top-level <code>name</code>/<code>version</code> in <code>META.json</code> (generated from <code>META.in.json</code> — you edit the latter, never <code>META.json</code> directly). An extension is the individual thing installed via <code>CREATE EXTENSION</code>, described by its own <code>.control</code> file. A single distribution routinely provides <strong>more than one</strong> extension — <code>META.in.json&#8217;s `provides</code> map lists each one; the pgTAP distribution, for example, provides both the <code>pgtap</code> and <code>schematap</code> extensions from one release.</p>
+</div>
+<div class="paragraph">
+<p>This split matters for versioning, and it&#8217;s where pgxntool has a real gap: <code>META.json&#8217;s top-level `version</code> is the <strong>distribution&#8217;s</strong> release version (used by <code>make tag</code> and <code>make dist</code> — it&#8217;s the git tag name and the <code>.zip</code> filename). Each extension&#8217;s <strong>own</strong> version, though, ends up tracked in <strong>two</strong> separate places that pgxntool does not keep in sync for you:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>the extension&#8217;s <code>.control</code> file (<code>default_version</code>) — what PostgreSQL and pgxntool&#8217;s own build actually use; see <a href="#_what_controls_the_version_number">What Controls the Version Number</a> below</p>
+</li>
+<li>
+<p>that extension&#8217;s entry under <code>META.in.json&#8217;s `provides</code> map (<code>provides.{extension}.version</code>) — which the PGXN meta spec defines as "a Version for the extension" in its own right, <strong>not</strong> the distribution&#8217;s version, and which is what PGXN&#8217;s public index reads</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Nothing generates one from the other or checks that they still agree, so it&#8217;s easy to bump one and forget the other; <a href="https://github.com/Postgres-Extensions/pgxntool/issues/47">issue #47</a> tracks fixing that.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_how_version_files_are_generated"><a class="anchor" href="#_how_version_files_are_generated"></a><a class="link" href="#_how_version_files_are_generated">5.2. How Version Files Are Generated</a></h3>
 <div class="paragraph">
 <p>When you run <code>make</code> (or <code>make all</code>), PGXNtool:</p>
 </div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>Reads your <code>META.json</code> file to determine the extension version from <code>provides.{extension}.version</code></p>
+<p>Reads each extension&#8217;s own <code>.control</code> file to determine its version from <code>default_version</code> (via <code>control.mk.sh</code>)</p>
 </li>
 <li>
 <p>Generates a Makefile rule that copies your base SQL file (<code>sql/{extension}.sql</code>) to the version-specific file (<code>sql/{extension}--{version}.sql</code>)</p>
@@ -1083,16 +1251,11 @@ The <code>pgtle</code> target is a dependency, so <code>make run-pgtle</code> wi
 </ol>
 </div>
 <div class="paragraph">
-<p>For example, if your <code>META.json</code> contains:</p>
+<p>For example, if your <code>myext.control</code> contains:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>"provides": {
-  "myext": {
-    "version": "1.2.3",
-    ...
-  }
-}</pre>
+<pre>default_version = '1.2.3'</pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1100,21 +1263,22 @@ The <code>pgtle</code> target is a dependency, so <code>make run-pgtle</code> wi
 </div>
 </div>
 <div class="sect2">
-<h3 id="_what_controls_the_version_number"><a class="anchor" href="#_what_controls_the_version_number"></a><a class="link" href="#_what_controls_the_version_number">5.2. What Controls the Version Number</a></h3>
+<h3 id="_what_controls_the_version_number"><a class="anchor" href="#_what_controls_the_version_number"></a><a class="link" href="#_what_controls_the_version_number">5.3. What Controls the Version Number</a></h3>
 <div class="paragraph">
-<p>The version number comes from <code>META.json</code> → <code>provides.{extension}.version</code>, <strong>not</strong> from your <code>.control</code> file&#8217;s <code>default_version</code> field. The <code>.control</code> file&#8217;s <code>default_version</code> is used by PostgreSQL to determine which version to install by default, but the actual version-specific file that gets generated is determined by what&#8217;s in <code>META.json</code>.</p>
+<p>The version number comes from each extension&#8217;s <strong>own</strong> <code>.control</code> file → <code>default_version</code>, <strong>not</strong> from <code>META.json</code>. PostgreSQL itself uses <code>default_version</code> to pick which versioned SQL file to load, so <code>control.mk.sh</code> parses the <code>.control</code> file(s) directly to keep the generated filename in sync with what PostgreSQL will actually use. <code>META.in.json</code> has its own, separate <code>provides.{extension}.version</code> for that same extension (see <a href="#_pgxn_distributions_vs_extensions">PGXN Distributions vs. Extensions</a> above) — pgxntool never reads it when generating SQL files, and nothing keeps it in sync with the <code>.control</code> file&#8217;s <code>default_version</code>.</p>
 </div>
 <div class="paragraph">
-<p>To change the version of your extension:
-1. Update <code>provides.{extension}.version</code> in <code>META.json</code>
+<p>To change the version of one of your extensions:
+1. Update <code>default_version</code> in that extension&#8217;s <code>.control</code> file
 2. Run <code>make</code> to regenerate the version-specific file
-3. Update <code>default_version</code> in your <code>.control</code> file to match (if needed)</p>
+3. Update that extension&#8217;s <code>provides.{extension}.version</code> in <code>META.in.json</code> to match by hand, and regenerate <code>META.json</code> (<code>make META.json</code>) — pgxntool won&#8217;t do this for you
+4. Update <code>META.in.json&#8217;s top-level `version</code> too if you&#8217;re also cutting a new distribution release</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_committing_version_files"><a class="anchor" href="#_committing_version_files"></a><a class="link" href="#_committing_version_files">5.3. Committing Version Files</a></h3>
+<h3 id="_committing_version_files"><a class="anchor" href="#_committing_version_files"></a><a class="link" href="#_committing_version_files">5.4. Committing Version Files</a></h3>
 <div class="paragraph">
-<p>Version-specific SQL files are now treated as permanent files that should be committed to your repository. This makes it much easier to test updates to extensions, as you can see exactly what SQL was included in each version.</p>
+<p>Version-specific SQL files are treated as permanent files that should be committed to your repository by default. This makes it much easier to test updates to extensions, as you can see exactly what SQL was included in each version.</p>
 </div>
 <div class="admonitionblock important">
 <table>
@@ -1128,9 +1292,82 @@ These files are auto-generated and include a header comment warning not to edit 
 </tr>
 </table>
 </div>
+<div class="sect3">
+<h4 id="_why_commit_them_update_testing"><a class="anchor" href="#_why_commit_them_update_testing"></a><a class="link" href="#_why_commit_them_update_testing">5.4.1. Why Commit Them: Update Testing</a></h4>
+<div class="paragraph">
+<p>The primary value of committing a version&#8217;s install script is <strong>update testing</strong>: with the file in place, you can install that exact version (<code>CREATE EXTENSION ext VERSION 'x.y.z'</code>), run <code>ALTER EXTENSION ext UPDATE</code>, and verify the update path actually works. In principle you would only ever need the very first committed version&#8217;s install script — every later version is reachable by chaining upgrade scripts from it. See <a href="#_testinstall">test/install</a> for how to wire this into your test suite.</p>
+</div>
+<div class="paragraph">
+<p>In practice, you should keep <strong>most</strong> old versions tracked rather than relying purely on that chain, because you cannot predict when a new <strong>major PostgreSQL version</strong> will break the ability to install an <strong>older</strong> extension version — a system catalog column changes type, a <code>SELECT *</code> over a catalog starts failing, and so on. Committing the old version&#8217;s install script lets CI catch that regression directly, by attempting to install that exact historical version against the new PostgreSQL release. For any non-trivial extension, most old versions should stay tracked for this reason alone.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_when_its_ok_to_skip_a_version"><a class="anchor" href="#_when_its_ok_to_skip_a_version"></a><a class="link" href="#_when_its_ok_to_skip_a_version">5.4.2. When It&#8217;s OK to Skip a Version</a></h4>
+<div class="paragraph">
+<p>For a <strong>minor version change that doesn&#8217;t meaningfully alter the extension</strong> (e.g. a small bug fix), it&#8217;s unlikely to straddle a PostgreSQL supported-version boundary, so there&#8217;s much less test-coverage value in committing that specific version&#8217;s generated install script. For large extensions, deliberately not committing some of these individual version files is worth doing to keep repository size down — the base <code>sql/{extension}.sql</code> still fully captures the change in git history, and the install script itself is trivially regenerated from that base file at build time.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_dont_gitignore_a_skipped_version_rm_it_once"><a class="anchor" href="#_dont_gitignore_a_skipped_version_rm_it_once"></a><a class="link" href="#_dont_gitignore_a_skipped_version_rm_it_once">5.4.3. Don&#8217;t <code>.gitignore</code> a Skipped Version — <code>rm</code> It Once</a></h4>
+<div class="paragraph">
+<p>When you decide not to track a particular version&#8217;s generated install script, do <strong>not</strong> add a <code>.gitignore</code> entry for it.</p>
+</div>
+<div class="paragraph">
+<p><code>make</code> only ever generates the <strong>current</strong> version&#8217;s file, stamped from the base source according to that extension&#8217;s <code>.control</code> file <code>default_version</code>. The moment you bump the version, <code>make</code> starts generating the <strong>new</strong> current version&#8217;s file and stops touching the old one — the old file left behind in your working tree is a stale, one-off artifact, not something <code>make</code> keeps recreating on every build.</p>
+</div>
+<div class="paragraph">
+<p>Because it&#8217;s only ever transiently present, the correct cleanup is a single <code>rm sql/{extension}--{old-version}.sql</code> right after the version bump — not a permanent <code>.gitignore</code> rule. A per-version <code>.gitignore</code> line would be perpetual clutter added on every release, for a file that&#8217;s only ever present for one build cycle. A broad glob (e.g. <code>sql/<strong>--</strong>.sql</code>) is wrong for the same reason it&#8217;s wrong below in <a href="#_alternative_ignoring_all_version_files">Alternative: Ignoring All Version Files</a>: it would also hide the prior-version install scripts and upgrade scripts (<code>sql/{extension}--{a}--{b}.sql</code>) that you <strong>do</strong> want tracked and visible in <code>git status</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_never_hand_edit_a_version_file_thats_no_longer_current"><a class="anchor" href="#_never_hand_edit_a_version_file_thats_no_longer_current"></a><a class="link" href="#_never_hand_edit_a_version_file_thats_no_longer_current">5.4.4. Never Hand-Edit a Version File That&#8217;s No Longer Current</a></h4>
+<div class="paragraph">
+<p><code>control.mk.sh</code> generates a Make rule along these lines for the current version&#8217;s file:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$(EXTENSION_ext_VERSION_FILE): sql/ext.sql extension.control
+	@echo '/* DO NOT EDIT - AUTO-GENERATED FILE */' &gt; $(EXTENSION_ext_VERSION_FILE)
+	@cat sql/ext.sql &gt;&gt; $(EXTENSION_ext_VERSION_FILE)</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>That rule only ever targets the file matching the extension&#8217;s <strong>current</strong> <code>default_version</code>, so editing the base <code>sql/{extension}.sql</code> and running <code>make</code> is the correct, safe way to change that one file.</p>
+</div>
+<div class="paragraph">
+<p>Every <strong>other</strong> versioned file — any <code>sql/{extension}--{version}.sql</code> where <code>{version}</code> is no longer current — is a frozen historical record, not something <code>make</code> will ever regenerate or overwrite again. Its entire purpose is to preserve exactly what shipped in that version (see <a href="#_why_commit_them_update_testing">Why Commit Them: Update Testing</a> above), so it can keep being used to test update paths and PostgreSQL-version compatibility against exactly what your users actually installed.</p>
+</div>
+<div class="paragraph">
+<p><strong>Hand-editing an old versioned file directly is never correct</strong> — it silently corrupts that historical record. If you need to change behavior after a version has already shipped, bump the version and add a proper <code>sql/{extension}--{old}--{new}.sql</code> upgrade script instead. Never edit <code>sql/{extension}--{old}.sql</code> in place.</p>
+</div>
+<div class="admonitionblock caution">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Caution</div>
+</td>
+<td class="content">
+This is especially relevant for AI coding agents, which won&#8217;t know this convention exists unless it&#8217;s spelled out. The generic <code>DO NOT EDIT - AUTO-GENERATED FILE</code> header on every version file doesn&#8217;t distinguish "regenerated on every build" (the current version) from "was generated once, now frozen" (every other version). An agent without this context may reasonably — but incorrectly — treat any auto-generated file as fair game to patch directly. Old versioned SQL files must instead be treated as append-only history: the fix is always a new version plus an upgrade script, never an in-place edit.
+</td>
+</tr>
+</table>
+</div>
+</div>
 </div>
 <div class="sect2">
-<h3 id="_alternative_ignoring_version_files"><a class="anchor" href="#_alternative_ignoring_version_files"></a><a class="link" href="#_alternative_ignoring_version_files">5.4. Alternative: Ignoring Version Files</a></h3>
+<h3 id="_alternative_ignoring_all_version_files"><a class="anchor" href="#_alternative_ignoring_all_version_files"></a><a class="link" href="#_alternative_ignoring_all_version_files">5.5. Alternative: Ignoring All Version Files</a></h3>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+This is a different, all-or-nothing choice from <a href="#_when_its_ok_to_skip_a_version">When It&#8217;s OK to Skip a Version</a> above, where the recommendation is to keep tracking most versions and selectively skip only a few low-value minor ones. This section instead covers not tracking <strong>any</strong> version-specific files at all.
+</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
 <p>If you prefer not to commit version-specific SQL files, you must add them to your <code>.gitignore</code> to prevent <code>make dist</code> from failing due to untracked files. Add the following to your <code>.gitignore</code>:</p>
 </div>
@@ -1158,13 +1395,13 @@ If you ignore version files instead of committing them, they will NOT be include
 </div>
 </div>
 <div class="sect2">
-<h3 id="_distribution_inclusion"><a class="anchor" href="#_distribution_inclusion"></a><a class="link" href="#_distribution_inclusion">5.5. Distribution Inclusion</a></h3>
+<h3 id="_distribution_inclusion"><a class="anchor" href="#_distribution_inclusion"></a><a class="link" href="#_distribution_inclusion">5.6. Distribution Inclusion</a></h3>
 <div class="paragraph">
 <p>Version-specific files are included in distributions created by <code>make dist</code> only if they are committed to git. Since <code>make dist</code> uses <code>git archive</code>, only tracked files are included in the distribution archive.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_multiple_versions"><a class="anchor" href="#_multiple_versions"></a><a class="link" href="#_multiple_versions">5.6. Multiple Versions</a></h3>
+<h3 id="_multiple_versions"><a class="anchor" href="#_multiple_versions"></a><a class="link" href="#_multiple_versions">5.7. Multiple Versions</a></h3>
 <div class="paragraph">
 <p>If you need to support multiple versions of your extension:</p>
 </div>
@@ -1177,7 +1414,7 @@ If you ignore version files instead of committing them, they will NOT be include
 <p>Create upgrade scripts for version transitions (e.g., <code>sql/myext&#8212;&#8203;1.0.0&#8212;&#8203;1.1.0.sql</code>)</p>
 </li>
 <li>
-<p>Update <code>META.json</code> to reflect the current version you&#8217;re working on</p>
+<p>Update <code>default_version</code> in the extension&#8217;s <code>.control</code> file to reflect the current version you&#8217;re working on</p>
 </li>
 <li>
 <p>Commit all version files and upgrade scripts to your repository</p>
@@ -1185,7 +1422,7 @@ If you ignore version files instead of committing them, they will NOT be include
 </ol>
 </div>
 <div class="paragraph">
-<p>The version file for the current version (specified in <code>META.json</code>) will be automatically regenerated when you run <code>make</code>, but other version files you create manually will be preserved.</p>
+<p>The version file for the current version (specified in the <code>.control</code> file&#8217;s <code>default_version</code>) will be automatically regenerated when you run <code>make</code>, but other version files you create manually will be preserved.</p>
 </div>
 </div>
 </div>
@@ -1251,9 +1488,8 @@ The result is appended to <code>ASCIIDOC_HTML</code> using <code>+=</code>.</p>
 <div class="sect2">
 <h3 id="_document_rules"><a class="anchor" href="#_document_rules"></a><a class="link" href="#_document_rules">6.2. Document Rules</a></h3>
 <div class="paragraph">
-<p>If Asciidoc is found (or <code>$(ASCIIDOC)</code> is set), the <code>html</code> rule will be added as a prerequisite to the <code>install</code> and <code>installchec</code> rules.
-That will ensure that docs are generated for install and test, but only if Asciidoc is available.
-The <code>dist</code> rule will always depend on <code>html</code> though, to ensure html files are up-to-date before creating a distribution.</p>
+<p>If Asciidoc is found (or <code>$(ASCIIDOC)</code> is set), <code>html</code> is added as a dependency of the <code>all</code> target, which both <code>install</code> and <code>installcheck</code> depend on — so docs get built for install and test, but only if Asciidoc is available.
+The <code>dist</code> rule always depends on <code>html</code> directly, regardless of whether Asciidoc was found, to ensure html files are up-to-date before creating a distribution.</p>
 </div>
 <div class="paragraph">
 <p>The <code>html</code> rule simply depends on `$(ASCIIDOC_HTML).
@@ -1268,11 +1504,11 @@ These rules are generated from <code>ASCIIDOC_template</code>:</p>
 <div class="content">
 <pre class="highlight"><code class="language-Makefile" data-lang="Makefile">define ASCIIDOC_template
 %.html: %.$(1) # <b class="conum">(1)</b>
-ifndef ASCIIDOC
+ifeq (,$(strip $(ASCIIDOC)))
 	$$(warning Could not find "asciidoc" or "asciidoctor". Add one of them to your PATH,)
 	$$(warning or set ASCIIDOC to the correct location.)
 	$$(error Could not build %$$@)
-endif # ifndef ASCIIDOC
+endif # ifeq ASCIIDOC
 	$$(ASCIIDOC) $$(ASCIIDOC_FLAGS) $$&lt;
 endef # define ASCIIDOC_template</code></pre>
 </div>
@@ -1288,6 +1524,9 @@ endef # define ASCIIDOC_template</code></pre>
 <p>These rules will <strong>always</strong> exist, even if <code>$(ASCIIDOC)</code> isn&#8217;t set (ie: if Asciidoc wasn&#8217;t found on the system).
 These rules will throw an error if they are run if <code>$(ASCIIDOC)</code> isn&#8217;t defined.
 On a normal user system that should never happen, because the <code>html</code> rule won&#8217;t be included in <code>install</code> or <code>installcheck</code>.</p>
+</div>
+<div class="paragraph">
+<p><code>make docclean</code> removes all generated HTML files (<code>$(DOCS_HTML)</code>). It&#8217;s separate from <code>make clean</code>/<code>make distclean</code>, so you can clear out generated docs without touching your build artifacts.</p>
 </div>
 </div>
 <div class="sect2">
@@ -1423,6 +1662,28 @@ This is only a basic example. Always refer to the <a href="https://github.com/aw
 </div>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_direct_pgtle_sh_invocation"><a class="anchor" href="#_direct_pgtle_sh_invocation"></a><a class="link" href="#_direct_pgtle_sh_invocation">7.5.2. Direct pgtle.sh Invocation</a></h4>
+<div class="paragraph">
+<p><code>pgtle</code>, <code>check-pgtle</code>, and <code>run-pgtle</code> are thin make wrappers around <code>pgxntool/pgtle.sh</code>. For more targeted operations you can run it directly:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>pgtle.sh --extension NAME [--pgtle-version VERSION]</code> — generate registration SQL for one extension (what <code>make pgtle</code> wraps).</p>
+</li>
+<li>
+<p><code>pgtle.sh --get-version</code> — print the pg_tle version installed in the target database (empty if not installed).</p>
+</li>
+<li>
+<p><code>pgtle.sh --get-dir VERSION</code> — print which version-range directory (see <a href="#_version_groupings">Version Groupings</a>) a given pg_tle version maps to, without generating anything.</p>
+</li>
+<li>
+<p><code>pgtle.sh --run</code> — execute the generated registration SQL against the target database (what <code>make run-pgtle</code> wraps).</p>
+</li>
+</ul>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_how_it_works"><a class="anchor" href="#_how_it_works"></a><a class="link" href="#_how_it_works">7.6. How It Works</a></h3>
@@ -1513,7 +1774,7 @@ Copyright (c) 2026 Jim Nasby &lt;<a href="mailto:Jim.Nasby@gmail.com">Jim.Nasby@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-03-26 16:45:03 -0500
+Last updated 2026-07-27 18:31:25 -0500
 </div>
 </div>
 </body>


### PR DESCRIPTION
## Summary
Follow-up from the new API documentation review process added in Postgres-Extensions/pgxntool-test#42. That PR's dry run compared `README.asc` against the actual code and found several real gaps — this PR fixes them.

**Corrections to existing docs (README described something code no longer does, or never did):**
- `test`'s prerequisites no longer include `clean` (removed a while back — it broke incremental/watch-based builds); README still listed it. Also documents the conditional `test-build` dependency.
- `verify-results` safeguard only documented the `regression.diffs` check; the actual default (`PGXNTOOL_VERIFY_RESULTS_MODE=pgtap`) scans test output for pgTAP failures first, falling back to `regression.diffs`. Documents the variable and both modes.
- `tag`: dropped the claim that it creates an *annotated* tag (it's `git tag NAME` — lightweight), and documented the skip-if-already-at-HEAD idempotency, which wasn't mentioned anywhere.
- `run-pgtle`: corrected the claimed make-level dependency on `check-pgtle` — that check actually happens inside `pgtle.sh` itself at runtime.
- Document Rules: fixed an `installcheck` typo and corrected how `html` actually gets wired in (via `all`, not directly as a prerequisite of `install`/`installcheck`).
- `ASCIIDOC_template` code sample: matched the real `ifeq (,$(strip $(ASCIIDOC)))` check in `base.mk` — the doc still showed an old `ifndef ASCIIDOC` version.

**New documentation for previously-undocumented items:**
- `dist`/`dist-only`: the `.gitattributes`-must-be-committed safety check, and `forcedist`.
- `list` and `print-%` — pgxntool's own dev-helper targets.
- `docclean`.
- `PGXNTOOL_NO_PGXS_INCLUDE`.
- `pgtle.sh`'s own CLI flags (`--get-version`, `--get-dir`, `--run`), not just the make targets that wrap them.
- `pgxntool-sync`: documents that every sync silently prunes `pgxntool/.github` and `pgxntool/.claude` from the consumer project (`prune_pgxntool_dev_dirs()` in `lib.sh`, added in #41) — this had never been mentioned anywhere.

**Deliberately left undocumented** (per review): `EXTRA_CLEAN += pg_tle/` (not worth a doc entry), and the internal conditional helper targets (`clean-test-build`, the install-schedule file target) that aren't meant to be invoked by hand.

No code changes — doc-only, so no `HISTORY.asc` entry.

Flag for review: the `.gitattributes`-must-be-committed note under `dist` documents `dist-only`'s existing safety check based on reading its implementation — please confirm the explanation is accurate.

## Test plan
- [x] `asciidoctor README.asc` renders clean with no new warnings (one pre-existing unrelated xref warning, `_Document_Handling`, predates this change).
- [x] Every corrected claim re-verified directly against current `base.mk`/`pgtle.sh`/`lib.sh` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)