### PR TITLE
ci: grant actions:write so bun cache save succeeds

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,11 @@ jobs:
       contents: read
       pull-requests: write   # post the review comments
       checks: read           # read sibling check-runs for the cost gate
+      # write (not just read) needed so claude-code-action's internal
+      # bun-setup step can save its cache; read-only causes a harmless but
+      # noisy "Cache reservation failed: cache write denied: token has no
+      # writable scopes" warning.
+      actions: write
     steps:
       # COST GATE: the paid Claude review is the last thing to run. Wait for the
       # PR head's OTHER check-runs to finish and only proceed if they are clean.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,12 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      # Required for Claude to read CI results on PRs. write (not just read)
+      # is also needed so claude-code-action's internal bun-setup step can
+      # save its cache; read-only causes a harmless but noisy
+      # "Cache reservation failed: cache write denied: token has no writable
+      # scopes" warning.
+      actions: write
     steps:
       - name: Checkout repository
         # Intentionally tracks the major-version tag (not a pinned SHA) so


### PR DESCRIPTION
## Summary
- `claude.yml` and `claude-code-review.yml` both run `anthropics/claude-code-action`, which internally uses `oven-sh/setup-bun` with caching enabled.
- Cache writes require `GITHUB_TOKEN` to have `actions: write`; with only `actions: read` (or none), every run logs a harmless but noisy warning: `Cache reservation failed: cache write denied: token has no writable scopes`.
- This grants `actions: write` in both workflows' job `permissions:` blocks.

## Security note
`actions: write` is coarse-grained — besides cache read/write it also allows cancelling/re-running workflow runs and deleting artifacts/logs, but grants no additional contents/PR/secrets access. For `claude-code-review.yml` (a `pull_request_target` workflow already gated to the trusted `jnasbyupgrade` fork owner), this is a modest increase to the existing prompt-injection blast radius described in that file's comments — it does not enable code execution or repo writes beyond what the workflow already has.

## Test plan
- [ ] Next CI run of `Claude Code` / `Claude Code Review` no longer shows the cache warning.