### PR TITLE
Fix stale README/CLAUDE.md docs; rename internal-only test shim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,11 +144,11 @@ make                    # Build extension (generates versioned SQL, docs)
 make test              # Full test: testdeps → install → installcheck → show diffs
 make results           # Run tests and update expected output files
 make html              # Generate HTML from Asciidoc sources
-make tag               # Create git branch for current META.json version
+make tag               # Create git tag for current META.json version
 make dist              # Create PGXN .zip (auto-tags, places in ../)
 make pgtle             # Generate pg_tle registration SQL (see pg_tle Support below)
 make check-pgtle       # Check pg_tle installation and report version
-make install-pgtle    # Install pg_tle registration SQL files into database
+make run-pgtle         # Register extensions with pg_tle in the database
 make pgxntool-sync     # Update to latest pgxntool via git subtree pull
 ```
 
@@ -204,7 +204,7 @@ When tests fail, examine the diff output carefully. The actual test output in `t
 
 ### Distribution Packaging
 - `make dist` creates `../PGXN-VERSION.zip`
-- Always creates git branch tag matching version
+- Always creates git tag matching version
 - Uses `git archive` to package
 - Validates repo is clean before tagging
 
@@ -227,16 +227,16 @@ pgxntool can generate pg_tle (Trusted Language Extensions) registration SQL for 
 
 **Installation targets:**
 
-- `make check-pgtle` - Checks if pg_tle is installed and reports the version. Reports version from `pg_extension` if extension has been created, or newest available version from `pg_available_extension_versions` if available but not created. Errors if pg_tle not available in cluster. Assumes `PG*` environment variables are configured.
+- `make check-pgtle` - Checks if pg_tle is installed and reports the version. Reports the version from `pg_extension` if `CREATE EXTENSION pg_tle` has been run in the database. Errors if pg_tle is not available in the cluster. Assumes `PG*` environment variables are configured.
 
-- `make install-pgtle` - Auto-detects pg_tle version and installs appropriate registration SQL files. Updates or creates pg_tle extension as needed. Determines which version range files to install based on detected version. Runs all generated SQL files via `psql` to register extensions with pg_tle. Assumes `PG*` environment variables are configured.
+- `make run-pgtle` - Registers all extensions with pg_tle by executing the generated pg_tle registration SQL files. Requires pg_tle to already be installed in the target database (`CREATE EXTENSION pg_tle;`) -- it does not create the extension itself, and errors out telling you to run `make check-pgtle` if it's missing. Depends on `pgtle`, so it generates the SQL files first if needed. Assumes `PG*` environment variables are configured.
 
 **Version notation:**
 - `X.Y.Z+` means >= X.Y.Z
 - `X.Y.Z-A.B.C` means >= X.Y.Z and < A.B.C (note boundary)
 
 **Key implementation details:**
-- Script: `pgxntool/pgtle-wrap.sh` (bash)
+- Script: `pgxntool/pgtle.sh` (bash)
 - Parses `.control` files for metadata (NOT META.json)
 - Fixed delimiter: `$_pgtle_wrap_delimiter_$` (validated not in source)
 - Each output file contains ALL versions and ALL upgrade paths

--- a/README.asc
+++ b/README.asc
@@ -9,7 +9,7 @@ PGXNtool is meant to make developing new Postgres extensions for http://pgxn.org
 
 Currently, it consists a base Makefile that you can include instead of writing your own, a template `META.in.json` (from which `META.json` is generated — you edit the former, never the latter directly), and some test framework. More features will be added over time.
 
-If you find any bugs or have ideas for improvements, please https://github.com/decibel/pgxntool/issues[*open an issue*].
+If you find any bugs or have ideas for improvements, please https://github.com/Postgres-Extensions/pgxntool/issues[*open an issue*].
 
 == Install
 This assumes that you've already initialized your extension in git.
@@ -17,7 +17,7 @@ This assumes that you've already initialized your extension in git.
 NOTE: The `--squash` is important! Otherwise you'll clutter your repo with a bunch of commits you probably don't want.
 
 ----
-git subtree add -P pgxntool --squash git@github.com:decibel/pgxntool.git release
+git subtree add -P pgxntool --squash git@github.com:Postgres-Extensions/pgxntool.git release
 pgxntool/setup.sh
 ----
 
@@ -213,7 +213,7 @@ check_control:
 	grep -q "requires = 'pgtap, test_factory'" test_factory_pgtap.control
 ----
 
-If you want to over-ride the default dependency on `pgtap` you should be able to do that with a makefile override. If you need help with that, please https://github.com/decibel/pgxntool/issues[open an issue].
+If you want to over-ride the default dependency on `pgtap` you should be able to do that with a makefile override. If you need help with that, please https://github.com/Postgres-Extensions/pgxntool/issues[open an issue].
 
 WARNING: It will probably cause problems if you try to create a `testdeps` rule that has a recipe. Instead of doing that, put the recipe in a separate rule and make that rule a prerequisite of `testdeps` as show in the example.
 
@@ -258,7 +258,7 @@ make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results
 
 If a tag for the current version already exists and points at your current commit, `make tag` does nothing — this makes it safe for other targets (like `dist`) to depend on `tag` without worrying about re-running it. If the existing tag points at a *different* commit — meaning you likely forgot to bump the version — you'll get an error. If you're certain you want to over-write the tag, you can do `make forcetag`, which removes the existing tag (via `make rmtag`) and creates a new one.
 
-WARNING: You will be very unhappy if you forget to update the .control file for your extension! There is an https://github.com/decibel/pgxntool/issues/1[open issue] to improve this.
+WARNING: You will be very unhappy if you forget to update the .control file for your extension! There is an https://github.com/Postgres-Extensions/pgxntool/issues/1[open issue] to improve this.
 
 === dist
 `make dist` will create a .zip file for your current version that you can upload to PGXN. It first runs `tag` (creating/pushing the version's git tag as described above if needed), then uses `git archive` at that tag to build the .zip file, so the archive always matches the exact tagged commit. The file is named after the PGXN name and version (the top-level "name" and "version" attributes in META.json, generated from `META.in.json`). The .zip file is placed in the *parent* directory so as not to clutter up your git repo.
@@ -277,6 +277,8 @@ NOTE: Your repository must be clean (no modified files) in order to run this. Ru
 NOTE: `git subtree pull` copies pgxntool's entire tree into your project, including dev-only directories (`pgxntool/.github`, `pgxntool/.claude`) that don't belong in a project that merely embeds pgxntool. Every sync automatically removes these two directories from `pgxntool/` afterward — this is expected, not a bug, and doesn't affect anything else in your project.
 
 TIP: The actual work is done by `pgxntool/pgxntool-sync.sh`, so you can run it directly (`pgxntool/pgxntool-sync.sh`) if you'd rather not go through `make`. It optionally takes `<repo>` and `<ref>` arguments to pull from somewhere other than the default.
+
+TIP: `pgxntool-sync.sh` itself delegates the 3-way merge of `setup.sh`-copied files to `pgxntool/update-setup-files.sh <old-pgxntool-commit>`, which you can also run directly -- for example, to redo or debug just the merge step without pulling again. `<old-pgxntool-commit>` is the pgxntool subtree commit that was current *before* the sync you want to re-merge.
 
 TIP: There is also a `pgxntool-sync-%` rule if you need to do more advanced things. `make pgxntool-sync-<name>` pulls from the `<repo> <ref>` defined by the `pgxntool-sync-<name>` make variable.
 
@@ -305,6 +307,12 @@ PGXNTOOL_distclean += my_generated_config.mk
 Generates pg_tle (Trusted Language Extensions) registration SQL files for deploying extensions in managed environments like AWS RDS/Aurora. See <<_pg_tle_Support>> for complete documentation.
 
 `make pgtle` generates SQL files in `pg_tle/` subdirectories organized by pg_tle version ranges. For version range details, see `pgtle_versions.md`.
+
+Set `PGTLE_VERSION` on the command line to limit generation to the single version range that value falls into, instead of every known range:
+
+----
+make pgtle PGTLE_VERSION=1.5.0
+----
 
 === check-pgtle
 Checks if pg_tle is installed and reports the version. This target:
@@ -406,8 +414,7 @@ Because it's only ever transiently present, the correct cleanup is a single `rm 
 
 ----
 $(EXTENSION_ext_VERSION_FILE): sql/ext.sql extension.control
-	@echo '/* DO NOT EDIT - AUTO-GENERATED FILE */' > $(EXTENSION_ext_VERSION_FILE)
-	@cat sql/ext.sql >> $(EXTENSION_ext_VERSION_FILE)
+	@(echo '/* DO NOT EDIT - AUTO-GENERATED FILE */'; cat sql/ext.sql) > $(EXTENSION_ext_VERSION_FILE)
 ----
 
 That rule only ever targets the file matching the extension's *current* `default_version`, so editing the base `sql/{extension}.sql` and running `make` is the correct, safe way to change that one file.
@@ -658,6 +665,10 @@ make dist PGXN_REMOTE=upstream
 
 Default: auto-detected, the first of `asciidoctor` or `asciidoc` found on `PATH`. Path to the Asciidoc processor used to build `.html` files from `$(ASCIIDOC_EXTS)` source files. Override if the processor you want isn't first on `PATH`, or isn't on `PATH` at all. See <<_document_handling>>.
 
+=== PGTLE_VERSION
+
+Default: unset (generates every known pg_tle version range). Set on the command line to limit `make pgtle` to the single version range this value falls into. See <<_pgtle>>.
+
 === PG_CONFIG
 
 Default: `pg_config`. Path to the `pg_config` binary used to detect the PostgreSQL version and locate PGXS. Override when the right `pg_config` isn't the one on `PATH`, such as when testing against a specific PostgreSQL install.
@@ -711,4 +722,4 @@ Default: unset (PGXS is included normally). Skips including PGXS (`$(PGXS)`) ent
 == Copyright
 Copyright (c) 2026 Jim Nasby <Jim.Nasby@gmail.com>
 
-PGXNtool is released under a https://github.com/decibel/pgxntool/blob/master/LICENCE[BSD license]. Note that it includes https://github.com/dominictarr/JSON.sh[JSON.sh], which is released under a https://github.com/decibel/pgxntool/blob/master/JSON.sh.LICENCE[MIT license].
+PGXNtool is released under a https://github.com/Postgres-Extensions/pgxntool/blob/master/LICENSE[BSD license]. Note that it includes https://github.com/dominictarr/JSON.sh[JSON.sh], which is released under a https://github.com/Postgres-Extensions/pgxntool/blob/master/JSON.sh.LICENSE[MIT license].

--- a/README.html
+++ b/README.html
@@ -499,16 +499,17 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_pgxn_remote">8.1. PGXN_REMOTE</a></li>
 <li><a href="#_asciidoc">8.2. ASCIIDOC</a></li>
-<li><a href="#_pg_config">8.3. PG_CONFIG</a></li>
-<li><a href="#_testdir">8.4. TESTDIR</a></li>
-<li><a href="#_testout">8.5. TESTOUT</a></li>
-<li><a href="#_pgxntool_verify_results_mode">8.6. PGXNTOOL_VERIFY_RESULTS_MODE</a></li>
-<li><a href="#_pgxntool_enable_test_build">8.7. PGXNTOOL_ENABLE_TEST_BUILD *</a></li>
-<li><a href="#_pgxntool_enable_test_install">8.8. PGXNTOOL_ENABLE_TEST_INSTALL *</a></li>
-<li><a href="#_pgxntool_enable_verify_results">8.9. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
-<li><a href="#_pgxntool_enable_check_stale_expected">8.10. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
-<li><a href="#_pgxntool_check_expected_file_types">8.11. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
-<li><a href="#_pgxntool_no_pgxs_include">8.12. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
+<li><a href="#_pgtle_version">8.3. PGTLE_VERSION</a></li>
+<li><a href="#_pg_config">8.4. PG_CONFIG</a></li>
+<li><a href="#_testdir">8.5. TESTDIR</a></li>
+<li><a href="#_testout">8.6. TESTOUT</a></li>
+<li><a href="#_pgxntool_verify_results_mode">8.7. PGXNTOOL_VERIFY_RESULTS_MODE</a></li>
+<li><a href="#_pgxntool_enable_test_build">8.8. PGXNTOOL_ENABLE_TEST_BUILD *</a></li>
+<li><a href="#_pgxntool_enable_test_install">8.9. PGXNTOOL_ENABLE_TEST_INSTALL *</a></li>
+<li><a href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
+<li><a href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
+<li><a href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
+<li><a href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
 </ul>
 </li>
 <li><a href="#_copyright">9. Copyright</a></li>
@@ -525,7 +526,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>Currently, it consists a base Makefile that you can include instead of writing your own, a template <code>META.in.json</code> (from which <code>META.json</code> is generated — you edit the former, never the latter directly), and some test framework. More features will be added over time.</p>
 </div>
 <div class="paragraph">
-<p>If you find any bugs or have ideas for improvements, please <a href="https://github.com/decibel/pgxntool/issues"><strong>open an issue</strong></a>.</p>
+<p>If you find any bugs or have ideas for improvements, please <a href="https://github.com/Postgres-Extensions/pgxntool/issues"><strong>open an issue</strong></a>.</p>
 </div>
 </div>
 </div>
@@ -549,7 +550,7 @@ The <code>--squash</code> is important! Otherwise you&#8217;ll clutter your repo
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>git subtree add -P pgxntool --squash git@github.com:decibel/pgxntool.git release
+<pre>git subtree add -P pgxntool --squash git@github.com:Postgres-Extensions/pgxntool.git release
 pgxntool/setup.sh</pre>
 </div>
 </div>
@@ -918,7 +919,7 @@ check_control:
 </div>
 </div>
 <div class="paragraph">
-<p>If you want to over-ride the default dependency on <code>pgtap</code> you should be able to do that with a makefile override. If you need help with that, please <a href="https://github.com/decibel/pgxntool/issues">open an issue</a>.</p>
+<p>If you want to over-ride the default dependency on <code>pgtap</code> you should be able to do that with a makefile override. If you need help with that, please <a href="https://github.com/Postgres-Extensions/pgxntool/issues">open an issue</a>.</p>
 </div>
 <div class="admonitionblock warning">
 <table>
@@ -1027,7 +1028,7 @@ make PGXNTOOL_ENABLE_VERIFY_RESULTS=no results</pre>
 <div class="title">Warning</div>
 </td>
 <td class="content">
-You will be very unhappy if you forget to update the .control file for your extension! There is an <a href="https://github.com/decibel/pgxntool/issues/1">open issue</a> to improve this.
+You will be very unhappy if you forget to update the .control file for your extension! There is an <a href="https://github.com/Postgres-Extensions/pgxntool/issues/1">open issue</a> to improve this.
 </td>
 </tr>
 </table>
@@ -1114,6 +1115,18 @@ The actual work is done by <code>pgxntool/pgxntool-sync.sh</code>, so you can ru
 <div class="title">Tip</div>
 </td>
 <td class="content">
+<code>pgxntool-sync.sh</code> itself delegates the 3-way merge of <code>setup.sh</code>-copied files to <code>pgxntool/update-setup-files.sh &lt;old-pgxntool-commit&gt;</code>, which you can also run directly&#8201;&#8212;&#8201;for example, to redo or debug just the merge step without pulling again. <code>&lt;old-pgxntool-commit&gt;</code> is the pgxntool subtree commit that was current <strong>before</strong> the sync you want to re-merge.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
 There is also a <code>pgxntool-sync-%</code> rule if you need to do more advanced things. <code>make pgxntool-sync-&lt;name&gt;</code> pulls from the <code>&lt;repo&gt; &lt;ref&gt;</code> defined by the <code>pgxntool-sync-&lt;name&gt;</code> make variable.
 </td>
 </tr>
@@ -1183,6 +1196,14 @@ PGXS doesn&#8217;t provide any special support for <code>distclean</code> — it
 </div>
 <div class="paragraph">
 <p><code>make pgtle</code> generates SQL files in <code>pg_tle/</code> subdirectories organized by pg_tle version ranges. For version range details, see <code>pgtle_versions.md</code>.</p>
+</div>
+<div class="paragraph">
+<p>Set <code>PGTLE_VERSION</code> on the command line to limit generation to the single version range that value falls into, instead of every known range:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>make pgtle PGTLE_VERSION=1.5.0</pre>
+</div>
 </div>
 </div>
 <div class="sect2">
@@ -1363,8 +1384,7 @@ These files are auto-generated and include a header comment warning not to edit 
 <div class="listingblock">
 <div class="content">
 <pre>$(EXTENSION_ext_VERSION_FILE): sql/ext.sql extension.control
-	@echo '/* DO NOT EDIT - AUTO-GENERATED FILE */' &gt; $(EXTENSION_ext_VERSION_FILE)
-	@cat sql/ext.sql &gt;&gt; $(EXTENSION_ext_VERSION_FILE)</pre>
+	@(echo '/* DO NOT EDIT - AUTO-GENERATED FILE */'; cat sql/ext.sql) &gt; $(EXTENSION_ext_VERSION_FILE)</pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1838,61 +1858,67 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pg_config"><a class="anchor" href="#_pg_config"></a><a class="link" href="#_pg_config">8.3. PG_CONFIG</a></h3>
+<h3 id="_pgtle_version"><a class="anchor" href="#_pgtle_version"></a><a class="link" href="#_pgtle_version">8.3. PGTLE_VERSION</a></h3>
+<div class="paragraph">
+<p>Default: unset (generates every known pg_tle version range). Set on the command line to limit <code>make pgtle</code> to the single version range this value falls into. See <a href="#_pgtle">pgtle</a>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_pg_config"><a class="anchor" href="#_pg_config"></a><a class="link" href="#_pg_config">8.4. PG_CONFIG</a></h3>
 <div class="paragraph">
 <p>Default: <code>pg_config</code>. Path to the <code>pg_config</code> binary used to detect the PostgreSQL version and locate PGXS. Override when the right <code>pg_config</code> isn&#8217;t the one on <code>PATH</code>, such as when testing against a specific PostgreSQL install.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_testdir"><a class="anchor" href="#_testdir"></a><a class="link" href="#_testdir">8.4. TESTDIR</a></h3>
+<h3 id="_testdir"><a class="anchor" href="#_testdir"></a><a class="link" href="#_testdir">8.5. TESTDIR</a></h3>
 <div class="paragraph">
 <p>Default: <code>test</code>. Root directory for test input files: <code>$(TESTDIR)/sql/</code>, <code>$(TESTDIR)/expected/</code>, <code>$(TESTDIR)/build/</code>, <code>$(TESTDIR)/install/</code>. Overriding this on its own is unusual; it mainly exists so <code>TESTOUT</code> has a sensible default.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_testout"><a class="anchor" href="#_testout"></a><a class="link" href="#_testout">8.5. TESTOUT</a></h3>
+<h3 id="_testout"><a class="anchor" href="#_testout"></a><a class="link" href="#_testout">8.6. TESTOUT</a></h3>
 <div class="paragraph">
 <p>Default: <code>$(TESTDIR)</code>. Directory <code>pg_regress</code> writes actual test output to&#8201;&#8212;&#8201;<code>$(TESTOUT)/results/</code>, <code>$(TESTOUT)/regression.diffs</code>, etc.&#8201;&#8212;&#8201;via <code>--outputdir</code> in <code>REGRESS_OPTS</code>. Kept separate from <code>TESTDIR</code> so generated output can be pointed somewhere other than the directory holding your checked-in <code>sql</code>/<code>expected</code> files, if you want that separation.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_verify_results_mode"><a class="anchor" href="#_pgxntool_verify_results_mode"></a><a class="link" href="#_pgxntool_verify_results_mode">8.6. PGXNTOOL_VERIFY_RESULTS_MODE</a></h3>
+<h3 id="_pgxntool_verify_results_mode"><a class="anchor" href="#_pgxntool_verify_results_mode"></a><a class="link" href="#_pgxntool_verify_results_mode">8.7. PGXNTOOL_VERIFY_RESULTS_MODE</a></h3>
 <div class="paragraph">
 <p>Default: <code>pgtap</code>. Controls how the <a href="#_verify_results_safeguard">verify-results safeguard</a> decides whether tests are failing.</p>
 </div>
 <div class="sect3">
-<h4 id="_pgtap"><a class="anchor" href="#_pgtap"></a><a class="link" href="#_pgtap">8.6.1. pgtap</a></h4>
+<h4 id="_pgtap"><a class="anchor" href="#_pgtap"></a><a class="link" href="#_pgtap">8.7.1. pgtap</a></h4>
 <div class="paragraph">
 <p>Scans <code>test/results/*.out</code> for pgTap <code>not ok</code> lines and plan mismatches, falling back to checking for <code>regression.diffs</code> too. Use this mode when your test suite uses pgTap.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_diffs"><a class="anchor" href="#_diffs"></a><a class="link" href="#_diffs">8.6.2. diffs</a></h4>
+<h4 id="_diffs"><a class="anchor" href="#_diffs"></a><a class="link" href="#_diffs">8.7.2. diffs</a></h4>
 <div class="paragraph">
 <p>Checks only for <code>regression.diffs</code>, matching classic pg_regress behavior. Use this mode when your tests use plain SQL expected-output comparison only.</p>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_test_build"><a class="anchor" href="#_pgxntool_enable_test_build"></a><a class="link" href="#_pgxntool_enable_test_build">8.7. PGXNTOOL_ENABLE_TEST_BUILD *</a></h3>
+<h3 id="_pgxntool_enable_test_build"><a class="anchor" href="#_pgxntool_enable_test_build"></a><a class="link" href="#_pgxntool_enable_test_build">8.8. PGXNTOOL_ENABLE_TEST_BUILD *</a></h3>
 <div class="paragraph">
 <p>Default: auto-detected&#8201;&#8212;&#8201;<code>yes</code> if <code>test/build/*.sql</code> files exist, <code>no</code> otherwise. Enables or disables the <a href="#_test_build">test-build</a> pre-flight SQL check. Set explicitly to <code>yes</code> if you want an error when <code>test/build/</code> unexpectedly has no SQL files (catches accidental deletion of its contents), or to <code>no</code> to disable the check even when files are present.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_test_install"><a class="anchor" href="#_pgxntool_enable_test_install"></a><a class="link" href="#_pgxntool_enable_test_install">8.8. PGXNTOOL_ENABLE_TEST_INSTALL *</a></h3>
+<h3 id="_pgxntool_enable_test_install"><a class="anchor" href="#_pgxntool_enable_test_install"></a><a class="link" href="#_pgxntool_enable_test_install">8.9. PGXNTOOL_ENABLE_TEST_INSTALL *</a></h3>
 <div class="paragraph">
 <p>Default: auto-detected&#8201;&#8212;&#8201;<code>yes</code> if <code>test/install/*.sql</code> files exist, <code>no</code> otherwise. Enables or disables the <a href="#_testinstall">test/install</a> schedule-based setup feature. Same explicit-override semantics as <code>PGXNTOOL_ENABLE_TEST_BUILD</code>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.9. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
+<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the <a href="#_verify_results_safeguard">verify-results safeguard</a> that blocks <code>make results</code> when tests are failing. Setting it to empty on the command line (<code>make PGXNTOOL_ENABLE_VERIFY_RESULTS= results</code>) also disables it.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.10. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
+<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the check-stale-expected safeguard, which fails <code>make test</code> if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains a <code>.out</code> file with no corresponding <code>.sql</code> file&#8201;&#8212;&#8201;catching a stale file left behind after a test was renamed or removed. Set to <code>no</code> to make the check a complete no-op (it&#8217;s dropped from <code>TEST_DEPS</code> entirely).</p>
 </div>
@@ -1901,13 +1927,13 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.11. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
+<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Sub-check of check-stale-expected, independent of <code>PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED</code>: fails (with a distinct error message and exit code from the orphaned-<code>.out</code> check) if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains any file that isn&#8217;t <code>*.out</code>. Set to <code>no</code> to disable just this sub-check while leaving the orphaned-<code>.out</code> check active.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.12. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
+<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
 <div class="paragraph">
 <p>Default: unset (PGXS is included normally). Skips including PGXS (<code>$(PGXS)</code>) entirely. This is only for advanced scenarios where you need to manage the PGXS include yourself; most projects should never set this.</p>
 </div>
@@ -1921,14 +1947,14 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 <p>Copyright (c) 2026 Jim Nasby &lt;<a href="mailto:Jim.Nasby@gmail.com">Jim.Nasby@gmail.com</a>&gt;</p>
 </div>
 <div class="paragraph">
-<p>PGXNtool is released under a <a href="https://github.com/decibel/pgxntool/blob/master/LICENCE">BSD license</a>. Note that it includes <a href="https://github.com/dominictarr/JSON.sh">JSON.sh</a>, which is released under a <a href="https://github.com/decibel/pgxntool/blob/master/JSON.sh.LICENCE">MIT license</a>.</p>
+<p>PGXNtool is released under a <a href="https://github.com/Postgres-Extensions/pgxntool/blob/master/LICENSE">BSD license</a>. Note that it includes <a href="https://github.com/dominictarr/JSON.sh">JSON.sh</a>, which is released under a <a href="https://github.com/Postgres-Extensions/pgxntool/blob/master/JSON.sh.LICENSE">MIT license</a>.</p>
 </div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-29 13:41:25 -0500
+Last updated 2026-07-29 14:55:58 -0500
 </div>
 </div>
 </body>

--- a/base.mk
+++ b/base.mk
@@ -211,14 +211,9 @@ PGXNTOOL_VERIFY_RESULTS_MODE ?= pgtap
 #   - Passed through to check-stale-expected.sh; see that script for the
 #     distinct error message/exit code this sub-check uses
 #
-# Variable: PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT
+# Variable: _CHECK_STALE_EXPECTED_SCRIPT (internal shim, not user-facing)
 #   - Path to the script the check-stale-expected target invokes
 #   - Default: $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
-#   - Exists so a test can swap in a stub script (e.g. one that just records
-#     that it was called) without needing to fake out any other part of
-#     PGXNTOOL_DIR, which many unrelated targets also read. See
-#     pgxntool-test's CLAUDE.md, "Proving a Script Was/Wasn't Invoked"
-#     (under "Testing"), for the pattern this supports.
 #
 # Implementation: See check-stale-expected target definition (search for
 # "check-stale-expected:" in this file)
@@ -235,7 +230,7 @@ else
   PGXNTOOL_CHECK_EXPECTED_FILE_TYPES = yes
 endif
 
-PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT ?= $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
+_CHECK_STALE_EXPECTED_SCRIPT ?= $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
 
 # Generate unique database name for tests to prevent conflicts across projects
 # Uses project name + first 5 chars of md5 hash of current directory
@@ -344,7 +339,7 @@ TEST_DEPS = testdeps
 ifeq ($(PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED),yes)
 .PHONY: check-stale-expected
 check-stale-expected: installcheck
-	@$(PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT) $(TESTDIR) $(PGXNTOOL_CHECK_EXPECTED_FILE_TYPES)
+	@$(_CHECK_STALE_EXPECTED_SCRIPT) $(TESTDIR) $(PGXNTOOL_CHECK_EXPECTED_FILE_TYPES)
 TEST_DEPS += check-stale-expected
 endif
 

--- a/setup.sh
+++ b/setup.sh
@@ -87,4 +87,4 @@ rmdir src
 
 If everything looks good then
 
-git commit -am 'Add pgxntool (https://github.com/decibel/pgxntool/tree/release)'"
+git commit -am 'Add pgxntool (https://github.com/Postgres-Extensions/pgxntool/tree/release)'"


### PR DESCRIPTION
Found by the `/release` skill's API documentation review ahead of 2.2.0.

- Rename `PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT` to `_CHECK_STALE_EXPECTED_SCRIPT`, establishing a leading-underscore convention for internal-only override points (test-stubbing seams, not user-facing config) that don't belong under the `PGXNTOOL_` prefix.
- Document `PGTLE_VERSION` in README.asc (pgtle section + Configuration Variables) -- it was fixed and used in HISTORY.asc/CLAUDE.md but never actually documented for users.
- Fix the versioned-SQL-file code example in README.asc, which still showed the truncate+append pattern that was fixed for parallel-build corruption.
- Update stale `decibel/pgxntool` URLs (Install command, issue links, license links) to `Postgres-Extensions/pgxntool`, and fix `LICENCE`/`JSON.sh.LICENCE` typos to `LICENSE`/`JSON.sh.LICENSE`.
- Document `update-setup-files.sh` as directly invokable in the pgxntool-sync section.
- Fix CLAUDE.md: nonexistent `install-pgtle` target -> `run-pgtle`, wrong `check-pgtle`/`run-pgtle` descriptions, wrong script name `pgtle-wrap.sh` -> `pgtle.sh`, and `make tag` creates a tag, not a branch.
- Regenerate README.html from README.asc.

Companion PR: https://github.com/Postgres-Extensions/pgxntool-test/pull/52 (renamed variable references + API-surface convention doc).

Not included per explicit decision: the `EXTRA_CLEAN`/`make clean` fix from a prior commit stays undocumented in HISTORY.asc (too minor to mention); `EXTENSION__CURRENT_VERSION__FILES` is left as-is (not meant to be overridden, just referenced).