### PR TITLE
Release 2.2.0

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,5 +1,18 @@
-STABLE
-------
+2.2.0
+-----
+== Add `check-stale-expected` to catch orphaned test/expected files
+`make test` now fails if `test/expected/*.out` (or `test/build/expected/*.out`)
+has no corresponding `test/sql/*.sql` (or `test/build/*.sql`). If your project
+has genuinely stale expected-output files sitting around, `make test` will
+newly fail until they're removed. pg_regress's alternate expected-output
+files (`test_0.out` .. `test_9.out`) are recognized and not flagged as stale.
+
+== Rename `EXTENSION_VERSION_FILES` to `EXTENSION__CURRENT_VERSION__FILES`
+The old name implied it listed every version file for an extension; it
+actually only ever holds the current/most-recent one per extension. If your
+Makefile references `EXTENSION_VERSION_FILES` directly (e.g. to add extra
+dependencies to `DATA`), update it to `EXTENSION__CURRENT_VERSION__FILES`.
+
 == Add `make pgxntool-version` to print the embedded pgxntool version
 There was no way to tell which pgxntool version a project had embedded via
 `git subtree` short of digging through git history. `make pgxntool-version`
@@ -8,16 +21,15 @@ first line of `pgxntool/HISTORY.asc` -- the same line the release process
 stamps with the version number. The line is rejected unless it's `STABLE`
 or a plain `X.Y.Z` version (digits only, no pre-release suffixes).
 
+== Add `PGXN_REMOTE` to override the remote used by tag/rmtag/forcetag/dist
+These targets hardcoded the `origin` remote, silently re-tagging the wrong
+repository for maintainers whose `origin` is a personal fork. Defaults to
+`origin`, so existing behavior is unchanged unless you set it.
+
 == Fix `make pgtle PGTLE_VERSION=X` generating all versions instead of one
 `base.mk`'s `pgtle` target never passed the `PGTLE_VERSION` make variable
 through to `pgtle.sh --pgtle-version`, so it silently generated all pg_tle
 version ranges regardless of the value given on the command line.
-
-== Rename `EXTENSION_VERSION_FILES` to `EXTENSION__CURRENT_VERSION__FILES`
-The old name implied it listed every version file for an extension; it
-actually only ever holds the current/most-recent one per extension. If your
-Makefile references `EXTENSION_VERSION_FILES` directly (e.g. to add extra
-dependencies to `DATA`), update it to `EXTENSION__CURRENT_VERSION__FILES`.
 
 == Fix `pgtle.sh` rejecting non-numeric version aliases like `stable`
 `extract_version_from_filename()` required every version segment to start
@@ -31,18 +43,6 @@ The rule generating `sql/<ext>--<version>.sql` used a `>` truncate followed
 by a separate `>>` append, so a rule that fired more than once (e.g.
 overlapping `make` processes) doubled the file's content. Now uses a single
 atomic redirect.
-
-== Add `check-stale-expected` to catch orphaned test/expected files
-`make test` now fails if `test/expected/*.out` (or `test/build/expected/*.out`)
-has no corresponding `test/sql/*.sql` (or `test/build/*.sql`). If your project
-has genuinely stale expected-output files sitting around, `make test` will
-newly fail until they're removed. pg_regress's alternate expected-output
-files (`test_0.out` .. `test_9.out`) are recognized and not flagged as stale.
-
-== Add `PGXN_REMOTE` to override the remote used by tag/rmtag/forcetag/dist
-These targets hardcoded the `origin` remote, silently re-tagging the wrong
-repository for maintainers whose `origin` is a personal fork. Defaults to
-`origin`, so existing behavior is unchanged unless you set it.
 
 == Add include guard to base.mk
 `base.mk` could end up included twice in one `make` run (for example, an


### PR DESCRIPTION
Stamps HISTORY.asc for 2.2.0. Companion (do-not-merge, CI trigger only): https://github.com/Postgres-Extensions/pgxntool-test/pull/53