### PR TITLE
Restrict @claude mention trigger to a trusted account

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,12 +14,8 @@ on:
 # serializing would only delay responses and cancelling would drop them.
 jobs:
   claude:
-    # SECURITY: gated to github.actor == 'jnasbyupgrade' so only that account
-    # can invoke Claude via @claude mentions. Without this, any GitHub user
-    # (or bot) commenting/opening an issue containing "@claude" would cause
-    # this job to run using the org's Claude Code OAuth token and a
-    # repo-scoped GITHUB_TOKEN. To add more trusted accounts, extend the
-    # actor check.
+    # SECURITY: restricts @claude to a single trusted account, not just
+    # matching comment text — otherwise anyone could trigger this job.
     if: |
       github.actor == 'jnasbyupgrade' &&
       (

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,11 +14,20 @@ on:
 # serializing would only delay responses and cancelling would drop them.
 jobs:
   claude:
+    # SECURITY: gated to github.actor == 'jnasbyupgrade' so only that account
+    # can invoke Claude via @claude mentions. Without this, any GitHub user
+    # (or bot) commenting/opening an issue containing "@claude" would cause
+    # this job to run using the org's Claude Code OAuth token and a
+    # repo-scoped GITHUB_TOKEN. To add more trusted accounts, extend the
+    # actor check.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'jnasbyupgrade' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
- Add an actor check to `claude.yml` so `@claude` mentions only run for a single trusted account.
- `claude-code-review.yml` is unchanged.

## Test plan
- [ ] Confirm `@claude` mentions from the trusted account still trigger the workflow
- [ ] Confirm mentions from any other account are skipped