### PR TITLE
Fix installcheck running before install; make test now fails on regressions

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -6,6 +6,8 @@ regardless of `pg_regress`'s exit status, and `test`'s recipe only `cat`ed
 `regression.diffs` for visibility without checking it. `make test` now exits
 non-zero when `regression.diffs` is non-empty, after printing it.
 
+Issues fixed in this release: #35, #49, #79
+
 2.2.0
 -----
 == Add `check-stale-expected` to catch orphaned test/expected files

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,11 @@
+STABLE
+------
+== Fix `make test` always exiting 0, even when every test fails
+`.IGNORE: installcheck` made `make` treat `installcheck` as always successful
+regardless of `pg_regress`'s exit status, and `test`'s recipe only `cat`ed
+`regression.diffs` for visibility without checking it. `make test` now exits
+non-zero when `regression.diffs` is non-empty, after printing it.
+
 2.2.0
 -----
 == Add `check-stale-expected` to catch orphaned test/expected files

--- a/base.mk
+++ b/base.mk
@@ -307,6 +307,17 @@ DATA += $(wildcard *.control)
 .IGNORE: installcheck
 installcheck: $(TEST_RESULT_FILES) $(TEST_SQL_FILES) | $(TESTDIR)/sql/ $(TESTDIR)/expected/ $(TESTOUT)/results/
 
+# installcheck must run after install: pg_regress needs the extension already
+# installed (CREATE EXTENSION requires the control/SQL files to be in place).
+# PGXS's own installcheck target doesn't declare that dependency -- it assumes
+# the caller runs `make install installcheck` manually. That assumption breaks
+# when something else (e.g. check-stale-expected below) depends on installcheck
+# directly: `test`'s TEST_DEPS lists install/installcheck as independent,
+# unordered prerequisites, so nothing stops installcheck's own prerequisite
+# chain from running before install. An explicit edge here, same as
+# check-stale-expected's, is the only ordering guarantee Make actually gives.
+installcheck: install
+
 #
 # TEST SUPPORT
 #
@@ -355,7 +366,7 @@ TEST_DEPS += test-build
 endif
 TEST_DEPS += install installcheck
 test: $(TEST_DEPS)
-	@if [ -r $(TESTOUT)/regression.diffs ]; then cat $(TESTOUT)/regression.diffs; fi
+	@if [ -r $(TESTOUT)/regression.diffs ]; then cat $(TESTOUT)/regression.diffs; exit 1; fi
 
 #
 # verify-results: Safeguard for make results
@@ -379,18 +390,27 @@ verify-results:
 endif
 endif
 
-# make results: runs `make test` and copies all result files to expected.
+# make results: runs the same steps as `make test` and copies all result files
+# to expected.
 # DO NOT RUN THIS UNLESS YOU'RE CERTAIN ALL YOUR TESTS ARE PASSING!
 #
-# Dependency chain (verify-results: test) guarantees test completes before verify-results
-# checks regression.diffs, even under make -j. Listing both as independent prerequisites
-# of results would allow them to run concurrently, letting verify-results see stale state.
+# Depends on $(TEST_DEPS) directly rather than on `test` itself: `test`'s own
+# recipe now exits non-zero as soon as it sees a regression.diffs mismatch
+# (see `test:` above), which would abort this chain before verify-results ever
+# got a chance to inspect the diff and report it properly. verify-results (or
+# the plain diffs check below, when disabled) is the one that's supposed to
+# decide pass/fail here, not `test`.
+#
+# Dependency chain (verify-results: $(TEST_DEPS)) guarantees those complete
+# before verify-results checks regression.diffs, even under make -j. Listing
+# them as independent prerequisites of results would allow them to run
+# concurrently, letting verify-results see stale state.
 .PHONY: results
 ifeq ($(PGXNTOOL_ENABLE_VERIFY_RESULTS),yes)
-verify-results: test
+verify-results: $(TEST_DEPS)
 results: verify-results
 else
-results: test
+results: $(TEST_DEPS)
 endif
 	@mkdir -p $(TESTDIR)/expected
 	@for f in $(TESTOUT)/results/*.out; do \


### PR DESCRIPTION
## Summary
- `installcheck` now has an explicit `install` prerequisite, so a fresh/uninstalled tree (e.g. CI) can't run pg_regress before the extension exists. `check-stale-expected`'s `check-stale-expected: installcheck` edge could previously pull `installcheck` in before `test`'s own `install installcheck` pair ran, since Make doesn't guarantee left-to-right order between unrelated prerequisites of the same target. Fixes #79.
- `test`'s recipe now exits non-zero when `regression.diffs` is non-empty (still printing the diff first). `.IGNORE: installcheck` made `installcheck`'s real pg_regress exit status irrelevant to Make, so `make test` always exited 0 -- even with every test failing -- silently defeating CI. Fixes #49.
- `results`/`verify-results` now depend on `$(TEST_DEPS)` directly instead of `test`, since `test`'s new exit-1-on-diff would otherwise abort the results-blessing workflow before verify-results got to inspect the diff itself.

Issue #35 is a duplicate report of the same `make test` always-exits-0 bug as #49 (same root cause, same suggested fix) -- also fixed by this PR.

Fixes #35.

Paired test coverage: Postgres-Extensions/pgxntool-test#59

## Test plan
- [x] Full pgxntool-test suite (`test-all`) run fresh against this branch: 250/250 passed, 0 failed, 0 skipped
- [x] New BATS coverage added for both issues (see paired pgxntool-test PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)