### PR TITLE
claude-code-review.yml: add missing --comment flag

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -112,4 +112,11 @@ jobs:
           # marketplace repo's default branch (upstream anthropics/claude-code).
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment is required: without it, the code-review plugin only
+          # prints its findings to the job log and never posts anything to
+          # the PR (confirmed by capturing the hidden SDK transcript on a
+          # canary PR in pgxntool-test: the review correctly found an
+          # injected bug but ended with "No `--comment` argument was
+          # provided, so no GitHub comments were posted"). Every review run
+          # before this fix has been silently invisible on GitHub.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'


### PR DESCRIPTION
## Summary
- Same issue as Postgres-Extensions/pgxntool-test#61: the `/code-review` plugin only prints its findings to the terminal/job log by default; it needs `--comment` to post a PR comment. This workflow's prompt was missing that flag, so every automated review has run (real API cost, correct analysis) but never posted anything visible to the PR.
- Root cause confirmed on the pgxntool-test side by temporarily enabling `show_full_output` on a canary PR with a deliberately injected bug: the review agent found the bug correctly, but its own final line read *"No `--comment` argument was provided, so no GitHub comments were posted."* Adding `--comment` fixed it there; this is the same one-line fix applied to pgxntool's copy of the workflow.

## Test plan
- [x] This change only affects a GitHub Actions workflow file; not covered by `make test`.
- [x] The fix was live-verified against pgxntool-test's identical workflow (Postgres-Extensions/pgxntool-test#61) before being ported here unchanged.