### PR TITLE
Rename PGTLE_VERSION to PGXNTOOL_PGTLE_VERSION

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ When tests fail, examine the diff output carefully. The actual test output in `t
 
 pgxntool can generate pg_tle (Trusted Language Extensions) registration SQL for deploying extensions in AWS RDS/Aurora without filesystem access.
 
-**Usage:** `make pgtle` or `make pgtle PGTLE_VERSION=1.5.0+`
+**Usage:** `make pgtle` or `make pgtle PGXNTOOL_PGTLE_VERSION=1.5.0+`
 
 **Output:** `pg_tle/{version_range}/{extension}.sql`
 

--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,16 @@
+STABLE
+------
+== Rename `PGTLE_VERSION` to `PGXNTOOL_PGTLE_VERSION`
+`make pgtle`'s version-limiting variable was named `PGTLE_VERSION`, which
+make auto-imports from an identically-named environment variable. That name
+is also a natural choice for a CI job's "which pg_tle to test against" env
+var -- when one was set, `make pgtle`/`make run-pgtle` silently misbehaved
+instead of erroring. Renamed to `PGXNTOOL_PGTLE_VERSION` to avoid the
+collision. If you invoke `make pgtle PGTLE_VERSION=...` directly, update it
+to `PGXNTOOL_PGTLE_VERSION`.
+
+Issues fixed in this release: #78
+
 2.2.0
 -----
 == Add `check-stale-expected` to catch orphaned test/expected files

--- a/README.asc
+++ b/README.asc
@@ -308,10 +308,10 @@ Generates pg_tle (Trusted Language Extensions) registration SQL files for deploy
 
 `make pgtle` generates SQL files in `pg_tle/` subdirectories organized by pg_tle version ranges. For version range details, see `pgtle_versions.md`.
 
-Set `PGTLE_VERSION` on the command line to limit generation to the single version range that value falls into, instead of every known range:
+Set `PGXNTOOL_PGTLE_VERSION` on the command line to limit generation to the single version range that value falls into, instead of every known range:
 
 ----
-make pgtle PGTLE_VERSION=1.5.0
+make pgtle PGXNTOOL_PGTLE_VERSION=1.5.0
 ----
 
 === check-pgtle
@@ -665,9 +665,9 @@ make dist PGXN_REMOTE=upstream
 
 Default: auto-detected, the first of `asciidoctor` or `asciidoc` found on `PATH`. Path to the Asciidoc processor used to build `.html` files from `$(ASCIIDOC_EXTS)` source files. Override if the processor you want isn't first on `PATH`, or isn't on `PATH` at all. See <<_document_handling>>.
 
-=== PGTLE_VERSION
+=== PGXNTOOL_PGTLE_VERSION
 
-Default: unset (generates every known pg_tle version range). Set on the command line to limit `make pgtle` to the single version range this value falls into. See <<_pgtle>>.
+Default: unset (generates every known pg_tle version range). Set on the command line to limit `make pgtle` to the single version range this value falls into. Not named `PGTLE_VERSION`: make auto-imports same-named environment variables, and that name collided silently with CI jobs that set a `PGTLE_VERSION` env var for an unrelated purpose (which pg_tle to test against). See <<_pgtle>>.
 
 === PG_CONFIG
 

--- a/README.html
+++ b/README.html
@@ -499,7 +499,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_pgxn_remote">8.1. PGXN_REMOTE</a></li>
 <li><a href="#_asciidoc">8.2. ASCIIDOC</a></li>
-<li><a href="#_pgtle_version">8.3. PGTLE_VERSION</a></li>
+<li><a href="#_pgxntool_pgtle_version">8.3. PGXNTOOL_PGTLE_VERSION</a></li>
 <li><a href="#_pg_config">8.4. PG_CONFIG</a></li>
 <li><a href="#_testdir">8.5. TESTDIR</a></li>
 <li><a href="#_testout">8.6. TESTOUT</a></li>
@@ -1198,11 +1198,11 @@ PGXS doesn&#8217;t provide any special support for <code>distclean</code> — it
 <p><code>make pgtle</code> generates SQL files in <code>pg_tle/</code> subdirectories organized by pg_tle version ranges. For version range details, see <code>pgtle_versions.md</code>.</p>
 </div>
 <div class="paragraph">
-<p>Set <code>PGTLE_VERSION</code> on the command line to limit generation to the single version range that value falls into, instead of every known range:</p>
+<p>Set <code>PGXNTOOL_PGTLE_VERSION</code> on the command line to limit generation to the single version range that value falls into, instead of every known range:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>make pgtle PGTLE_VERSION=1.5.0</pre>
+<pre>make pgtle PGXNTOOL_PGTLE_VERSION=1.5.0</pre>
 </div>
 </div>
 </div>
@@ -1858,9 +1858,9 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgtle_version"><a class="anchor" href="#_pgtle_version"></a><a class="link" href="#_pgtle_version">8.3. PGTLE_VERSION</a></h3>
+<h3 id="_pgxntool_pgtle_version"><a class="anchor" href="#_pgxntool_pgtle_version"></a><a class="link" href="#_pgxntool_pgtle_version">8.3. PGXNTOOL_PGTLE_VERSION</a></h3>
 <div class="paragraph">
-<p>Default: unset (generates every known pg_tle version range). Set on the command line to limit <code>make pgtle</code> to the single version range this value falls into. See <a href="#_pgtle">pgtle</a>.</p>
+<p>Default: unset (generates every known pg_tle version range). Set on the command line to limit <code>make pgtle</code> to the single version range this value falls into. Not named <code>PGTLE_VERSION</code>: make auto-imports same-named environment variables, and that name collided silently with CI jobs that set a <code>PGTLE_VERSION</code> env var for an unrelated purpose (which pg_tle to test against). See <a href="#_pgtle">pgtle</a>.</p>
 </div>
 </div>
 <div class="sect2">
@@ -1954,7 +1954,7 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-29 14:55:58 -0500
+Last updated 2026-07-31 15:09:00 -0500
 </div>
 </div>
 </body>

--- a/base.mk
+++ b/base.mk
@@ -414,11 +414,15 @@ PGXNTOOL_EXTENSIONS = $(basename $(PGXNTOOL_CONTROL_FILES))
 # Depend on control.mk (which defines EXTENSION__CURRENT_VERSION__FILES)
 # Depend on control files explicitly so changes trigger rebuilds
 # Generates all supported pg_tle versions for each extension, unless
-# PGTLE_VERSION is set on the command line to limit output to one range
+# PGXNTOOL_PGTLE_VERSION is set on the command line to limit output to one
+# range. Deliberately not named PGTLE_VERSION: make auto-imports same-named
+# environment variables, and PGTLE_VERSION is a natural name for a CI job's
+# "which pg_tle to test against" env var (see issue #78) -- that collided
+# with this variable silently instead of erroring.
 .PHONY: pgtle
 pgtle: all control.mk $(PGXNTOOL_CONTROL_FILES)
 	@$(foreach ext,$(PGXNTOOL_EXTENSIONS),\
-		$(PGXNTOOL_DIR)/pgtle.sh --extension $(ext) $(if $(PGTLE_VERSION),--pgtle-version $(PGTLE_VERSION));)
+		$(PGXNTOOL_DIR)/pgtle.sh --extension $(ext) $(if $(PGXNTOOL_PGTLE_VERSION),--pgtle-version $(PGXNTOOL_PGTLE_VERSION));)
 
 #
 # pg_tle installation support


### PR DESCRIPTION
## Summary
- `base.mk`'s `pgtle` target read a make variable named `PGTLE_VERSION` to limit generation to one version range. Make auto-imports environment variables of the same name into unset make variables, and `PGTLE_VERSION` is also a natural name for a CI job's "which pg_tle to test against" env var — when one was set, `make pgtle`/`make run-pgtle` silently misbehaved instead of erroring.
- Renamed to `PGXNTOOL_PGTLE_VERSION` to avoid the collision.
- Updated `README.asc`/`README.html`, `CLAUDE.md`, and added a `STABLE` `HISTORY.asc` entry.

Fixes #78.

Companion pgxntool-test PR: Postgres-Extensions/pgxntool-test#64