### PR TITLE
Release 2.3.0

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,13 +1,5 @@
-STABLE
-------
-== Fix `DATA` wildcard skipping historical full-install version scripts
-`base.mk`'s `DATA` wildcard (`sql/*--*--*.sql`) only matched upgrade scripts
-(two `--` separators), silently skipping historical full-install scripts
-like `sql/ext--0.9.6.sql` (one `--`) even though these are meant to be
-committed to git. `make install` never placed them in the extension
-directory, so `CREATE EXTENSION ext VERSION 'x.y.z'` failed for any version
-older than current. Widened to `sql/*--*.sql`, which matches both.
-
+2.3.0
+-----
 == Rename `PGTLE_VERSION` to `PGXNTOOL_PGTLE_VERSION`
 `make pgtle`'s version-limiting variable was named `PGTLE_VERSION`, which
 make auto-imports from an identically-named environment variable. That name
@@ -16,6 +8,14 @@ var -- when one was set, `make pgtle`/`make run-pgtle` silently misbehaved
 instead of erroring. Renamed to `PGXNTOOL_PGTLE_VERSION` to avoid the
 collision. If you invoke `make pgtle PGTLE_VERSION=...` directly, update it
 to `PGXNTOOL_PGTLE_VERSION`.
+
+== Fix `DATA` wildcard skipping historical full-install version scripts
+`base.mk`'s `DATA` wildcard (`sql/*--*--*.sql`) only matched upgrade scripts
+(two `--` separators), silently skipping historical full-install scripts
+like `sql/ext--0.9.6.sql` (one `--`) even though these are meant to be
+committed to git. `make install` never placed them in the extension
+directory, so `CREATE EXTENSION ext VERSION 'x.y.z'` failed for any version
+older than current. Widened to `sql/*--*.sql`, which matches both.
 
 == Fix `make test` always exiting 0, even when every test fails
 `.IGNORE: installcheck` made `make` treat `installcheck` as always successful

--- a/README.asc
+++ b/README.asc
@@ -51,6 +51,8 @@ Whether `test-build` runs is controlled by the `PGXNTOOL_ENABLE_TEST_BUILD` vari
 
 NOTE: `test` intentionally does *not* depend on `clean` — that caused problems with incremental/watch-based builds. If your tests need a clean build to pass, that's a sign of a missing dependency elsewhere rather than something to fix by adding `clean` back.
 
+NOTE: `test` exits non-zero (after printing `regression.diffs`) if any test fails. Previously it always exited 0 regardless of test results, silently masking failures from CI and other automation that relies on the exit code.
+
 NOTE: While you can still run `make installcheck` or any other valid PGXS make target directly, it's recommended to use `make test` when using pgxntool. The `test` target ensures proper test isolation and correct dependency installation.
 
 === test-build


### PR DESCRIPTION
Stamps HISTORY.asc for 2.3.0. This PR should be merged normally.

Companion PR (must NOT be merged -- exists only to trigger a real CI test run): Postgres-Extensions/pgxntool-test#67