### PR TITLE
Add PGXNTOOL_ENABLE_FS_INSTALL and PGXNTOOL_ENABLE_PGXN_INSTALL

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,23 @@
+STABLE
+------
+== Add `PGXNTOOL_ENABLE_FS_INSTALL` and `PGXNTOOL_ENABLE_PGXN_INSTALL`
+`test`/`verify-results` unconditionally filesystem-installed the extension
+(via PGXS's `install`), and `installcheck` unconditionally auto-installed
+the pgtap dependency via `pgxn install pgtap --sudo` when it wasn't already
+present -- with no way to disable either. That defeated "existing mode"
+testing, where the extension (and/or pgtap) was deployed some other way,
+e.g. registered via pg_tle instead of the filesystem: calling `test` or
+`verify-results` would silently filesystem-install as a side effect,
+undermining the point of proving the other deployment path works.
+
+`PGXNTOOL_ENABLE_FS_INSTALL` (default `yes`) now gates `install` as a
+prerequisite of `test`/`verify-results`, and whether `installcheck` depends
+on `install`. `PGXNTOOL_ENABLE_PGXN_INSTALL` (default: follows
+`PGXNTOOL_ENABLE_FS_INSTALL`, but can be set independently) gates the pgtap
+auto-install. Set either to `no` to disable.
+
+Issues fixed in this release: #55, #90
+
 2.3.0
 -----
 == Rename `PGTLE_VERSION` to `PGXNTOOL_PGTLE_VERSION`

--- a/README.asc
+++ b/README.asc
@@ -55,6 +55,8 @@ NOTE: `test` exits non-zero (after printing `regression.diffs`) if any test fail
 
 NOTE: While you can still run `make installcheck` or any other valid PGXS make target directly, it's recommended to use `make test` when using pgxntool. The `test` target ensures proper test isolation and correct dependency installation.
 
+Whether `test`/`installcheck`/`verify-results` filesystem-install the extension first is controlled by `PGXNTOOL_ENABLE_FS_INSTALL`, and whether `installcheck` auto-installs the pgtap dependency via `pgxn install` is controlled by `PGXNTOOL_ENABLE_PGXN_INSTALL` — see <<_pgxntool_enable_fs_install>> and <<_pgxntool_enable_pgxn_install>> for "existing mode"/pg_tle-style testing, where the extension (and/or pgtap) was deployed some other way and a filesystem install would defeat the point of the test.
+
 === test-build
 Validates that extension SQL files are syntactically correct before running the full test suite. This feature runs SQL files from `test/build/` through `pg_regress`, providing better error messages than `CREATE EXTENSION` failures when there are syntax errors in your extension code.
 
@@ -717,6 +719,14 @@ Default: auto-detected -- `yes` if `test/build/*.sql` files exist, `no` otherwis
 === PGXNTOOL_ENABLE_TEST_INSTALL *
 
 Default: auto-detected -- `yes` if `test/install/*.sql` files exist, `no` otherwise. Enables or disables the <<_testinstall,test/install>> schedule-based setup feature. Same explicit-override semantics as `PGXNTOOL_ENABLE_TEST_BUILD`.
+
+=== PGXNTOOL_ENABLE_FS_INSTALL *
+
+Default: `yes`. Controls whether `install` is a prerequisite of `test`/`verify-results`, and whether `installcheck` depends on `install`. Set to `no` for "existing mode" testing, where the extension under test was deployed some other way (e.g. registered via pg_tle instead of the filesystem, or installed by a binary pg_upgrade) -- with this set, `make test`/`make installcheck`/`make verify-results` run against whatever is already installed instead of filesystem-installing first.
+
+=== PGXNTOOL_ENABLE_PGXN_INSTALL *
+
+Default: follows `PGXNTOOL_ENABLE_FS_INSTALL` (so it's off automatically whenever filesystem install is off), but can be set independently. Controls whether `installcheck` auto-installs the pgtap dependency via `pgxn install pgtap --sudo` when it isn't already filesystem-installed. Set to `no` to make this a complete no-op, e.g. when pgtap is already provided some other way and you don't want a `sudo pgxn install` invoked as a side effect of testing.
 
 === PGXNTOOL_ENABLE_VERIFY_RESULTS *
 

--- a/README.html
+++ b/README.html
@@ -507,10 +507,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_pgxntool_verify_results_mode">8.7. PGXNTOOL_VERIFY_RESULTS_MODE</a></li>
 <li><a href="#_pgxntool_enable_test_build">8.8. PGXNTOOL_ENABLE_TEST_BUILD *</a></li>
 <li><a href="#_pgxntool_enable_test_install">8.9. PGXNTOOL_ENABLE_TEST_INSTALL *</a></li>
-<li><a href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
-<li><a href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
-<li><a href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
-<li><a href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
+<li><a href="#_pgxntool_enable_fs_install">8.10. PGXNTOOL_ENABLE_FS_INSTALL *</a></li>
+<li><a href="#_pgxntool_enable_pgxn_install">8.11. PGXNTOOL_ENABLE_PGXN_INSTALL *</a></li>
+<li><a href="#_pgxntool_enable_verify_results">8.12. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
+<li><a href="#_pgxntool_enable_check_stale_expected">8.13. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
+<li><a href="#_pgxntool_check_expected_file_types">8.14. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
+<li><a href="#_pgxntool_no_pgxs_include">8.15. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
 </ul>
 </li>
 <li><a href="#_copyright">9. Copyright</a></li>
@@ -635,10 +637,25 @@ all the targets normally provided by Postgres <a href="http://www.postgresql.org
 <div class="title">Note</div>
 </td>
 <td class="content">
+<code>test</code> exits non-zero (after printing <code>regression.diffs</code>) if any test fails. Previously it always exited 0 regardless of test results, silently masking failures from CI and other automation that relies on the exit code.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
 While you can still run <code>make installcheck</code> or any other valid PGXS make target directly, it&#8217;s recommended to use <code>make test</code> when using pgxntool. The <code>test</code> target ensures proper test isolation and correct dependency installation.
 </td>
 </tr>
 </table>
+</div>
+<div class="paragraph">
+<p>Whether <code>test</code>/<code>installcheck</code>/<code>verify-results</code> filesystem-install the extension first is controlled by <code>PGXNTOOL_ENABLE_FS_INSTALL</code>, and whether <code>installcheck</code> auto-installs the pgtap dependency via <code>pgxn install</code> is controlled by <code>PGXNTOOL_ENABLE_PGXN_INSTALL</code> — see <a href="#_pgxntool_enable_fs_install">PGXNTOOL_ENABLE_FS_INSTALL *</a> and <a href="#_pgxntool_enable_pgxn_install">PGXNTOOL_ENABLE_PGXN_INSTALL *</a> for "existing mode"/pg_tle-style testing, where the extension (and/or pgtap) was deployed some other way and a filesystem install would defeat the point of the test.</p>
 </div>
 </div>
 <div class="sect2">
@@ -1071,7 +1088,7 @@ If your project has a <code>.gitattributes</code> file, <code>make dist</code>/<
 <div class="sect2">
 <h3 id="_pgxntool_sync"><a class="anchor" href="#_pgxntool_sync"></a><a class="link" href="#_pgxntool_sync">4.9. pgxntool-sync</a></h3>
 <div class="paragraph">
-<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code> and then reconcile the files <code>setup.sh</code> copied into your project (<code>.gitignore</code>, <code>test/deps.sql</code>) with a 3-way merge.</p>
+<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code> and then reconcile the files <code>setup.sh</code> copied into your project (<code>.gitignore</code>, <code>test/deps.sql</code>) with a 3-way merge (it also verifies the <code>test/pgxntool</code> symlink, recreating it if missing).</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -1941,13 +1958,25 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
+<h3 id="_pgxntool_enable_fs_install"><a class="anchor" href="#_pgxntool_enable_fs_install"></a><a class="link" href="#_pgxntool_enable_fs_install">8.10. PGXNTOOL_ENABLE_FS_INSTALL *</a></h3>
+<div class="paragraph">
+<p>Default: <code>yes</code>. Controls whether <code>install</code> is a prerequisite of <code>test</code>/<code>verify-results</code>, and whether <code>installcheck</code> depends on <code>install</code>. Set to <code>no</code> for "existing mode" testing, where the extension under test was deployed some other way (e.g. registered via pg_tle instead of the filesystem, or installed by a binary pg_upgrade)&#8201;&#8212;&#8201;with this set, <code>make test</code>/<code>make installcheck</code>/<code>make verify-results</code> run against whatever is already installed instead of filesystem-installing first.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_pgxntool_enable_pgxn_install"><a class="anchor" href="#_pgxntool_enable_pgxn_install"></a><a class="link" href="#_pgxntool_enable_pgxn_install">8.11. PGXNTOOL_ENABLE_PGXN_INSTALL *</a></h3>
+<div class="paragraph">
+<p>Default: follows <code>PGXNTOOL_ENABLE_FS_INSTALL</code> (so it&#8217;s off automatically whenever filesystem install is off), but can be set independently. Controls whether <code>installcheck</code> auto-installs the pgtap dependency via <code>pgxn install pgtap --sudo</code> when it isn&#8217;t already filesystem-installed. Set to <code>no</code> to make this a complete no-op, e.g. when pgtap is already provided some other way and you don&#8217;t want a <code>sudo pgxn install</code> invoked as a side effect of testing.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.12. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the <a href="#_verify_results_safeguard">verify-results safeguard</a> that blocks <code>make results</code> when tests are failing. Setting it to empty on the command line (<code>make PGXNTOOL_ENABLE_VERIFY_RESULTS= results</code>) also disables it.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
+<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.13. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the check-stale-expected safeguard, which fails <code>make test</code> if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains a <code>.out</code> file with no corresponding <code>.sql</code> file&#8201;&#8212;&#8201;catching a stale file left behind after a test was renamed or removed. Set to <code>no</code> to make the check a complete no-op (it&#8217;s dropped from <code>TEST_DEPS</code> entirely).</p>
 </div>
@@ -1956,13 +1985,13 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
+<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.14. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Sub-check of check-stale-expected, independent of <code>PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED</code>: fails (with a distinct error message and exit code from the orphaned-<code>.out</code> check) if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains any file that isn&#8217;t <code>*.out</code>. Set to <code>no</code> to disable just this sub-check while leaving the orphaned-<code>.out</code> check active.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
+<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.15. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
 <div class="paragraph">
 <p>Default: unset (PGXS is included normally). Skips including PGXS (<code>$(PGXS)</code>) entirely. This is only for advanced scenarios where you need to manage the PGXS include yourself; most projects should never set this.</p>
 </div>
@@ -1983,7 +2012,7 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-31 16:13:06 -0500
+Last updated 2026-08-01 16:35:52 -0500
 </div>
 </div>
 </body>

--- a/base.mk
+++ b/base.mk
@@ -759,6 +759,15 @@ endif
 # $(DESTDIR)$(datadir) aren't being expanded. This can probably change after
 # the META handling stuff is it's own makefile.
 #
+#
+# This declaration is deliberately OUTSIDE the ifeq below (unlike e.g.
+# check-stale-expected's own .PHONY, which lives inside its ifeq): testdeps'
+# own `testdeps: pgtap` prerequisite (see testdeps' definition) is
+# unconditional, so pgtap must always resolve to *some* rule. Without this
+# unconditional .PHONY, disabling the block below would leave `pgtap`
+# completely undefined, and testdeps would fail with "No rule to make
+# target 'pgtap'". An empty phony rule (no prerequisites, no recipe) is
+# exactly the harmless no-op that's needed in that case.
 .PHONY: pgtap
 # Gated behind PGXNTOOL_ENABLE_PGXN_INSTALL (see its definition above): when
 # disabled, pgtap is a no-op and pg_regress runs assuming pgtap is already

--- a/base.mk
+++ b/base.mk
@@ -122,6 +122,65 @@ else
 endif
 
 # ------------------------------------------------------------------------------
+# install/installcheck: Filesystem-install the extension before testing
+# ------------------------------------------------------------------------------
+# Purpose: `test`/`verify-results` normally filesystem-install the extension
+#          (PGXS's `install`) before running pg_regress against it. That's
+#          wrong for "existing mode" testing, where the extension under test
+#          was deployed some other way (e.g. registered via pg_tle instead of
+#          the filesystem, or installed by a binary pg_upgrade) -- the whole
+#          point of that kind of test is to prove the other deployment path
+#          works, and a silent filesystem install as a side effect defeats it.
+#
+# Variable: PGXNTOOL_ENABLE_FS_INSTALL
+#   - Can be set manually in Makefile or command line
+#   - Allowed values: "yes" or "no" (case-insensitive)
+#   - Default: "yes" (enabled by default for all pgxntool projects)
+#   - Set to "no" to drop `install` from TEST_DEPS and stop `installcheck`
+#     from depending on `install`, so `make test`/`make installcheck`/
+#     `make verify-results` run against whatever is already installed
+#     instead of filesystem-installing first
+#
+# Implementation: See TEST_DEPS assembly and the `installcheck: install`
+# edge below (search for "PGXNTOOL_ENABLE_FS_INSTALL" in this file)
+#
+ifdef PGXNTOOL_ENABLE_FS_INSTALL
+  override PGXNTOOL_ENABLE_FS_INSTALL := $(call pgxntool_validate_yesno,$(PGXNTOOL_ENABLE_FS_INSTALL),PGXNTOOL_ENABLE_FS_INSTALL)
+else
+  PGXNTOOL_ENABLE_FS_INSTALL = yes
+endif
+
+# ------------------------------------------------------------------------------
+# pgtap: Auto-install the pgtap dependency via `pgxn install --sudo`
+# ------------------------------------------------------------------------------
+# Purpose: `installcheck` depends on pgtap being filesystem-installed, and
+#          auto-installs it via `pgxn install pgtap --sudo` when it isn't
+#          found already. That's itself a filesystem-install side effect --
+#          the same problem PGXNTOOL_ENABLE_FS_INSTALL above solves for the
+#          extension under test -- so it needs its own way to disable, and
+#          it makes no sense to leave it on when filesystem install is
+#          otherwise turned off.
+#
+# Variable: PGXNTOOL_ENABLE_PGXN_INSTALL
+#   - Can be set manually in Makefile or command line
+#   - Allowed values: "yes" or "no" (case-insensitive)
+#   - Default: follows PGXNTOOL_ENABLE_FS_INSTALL (off automatically
+#     whenever filesystem install is off), but can be set independently --
+#     e.g. to keep PGXNTOOL_ENABLE_FS_INSTALL=yes for your own extension
+#     while still skipping the pgxn auto-install of pgtap because it's
+#     already provided some other way
+#   - Set to "no" to make `pgtap` (and the `installcheck: pgtap` edge) a
+#     complete no-op: pg_regress runs assuming pgtap is already available
+#
+# Implementation: See pgtap target definition (search for "pgtap:" in this file)
+#
+ifdef PGXNTOOL_ENABLE_PGXN_INSTALL
+  override PGXNTOOL_ENABLE_PGXN_INSTALL := $(call pgxntool_validate_yesno,$(PGXNTOOL_ENABLE_PGXN_INSTALL),PGXNTOOL_ENABLE_PGXN_INSTALL)
+else
+  PGXNTOOL_ENABLE_PGXN_INSTALL = $(PGXNTOOL_ENABLE_FS_INSTALL)
+endif
+
+# ------------------------------------------------------------------------------
 # test/install: Run setup files before all tests in the same pg_regress session
 # ------------------------------------------------------------------------------
 # Purpose: Runs files from test/install/ before all test/sql/ files within a
@@ -323,7 +382,13 @@ installcheck: $(TEST_RESULT_FILES) $(TEST_SQL_FILES) | $(TESTDIR)/sql/ $(TESTDIR
 # unordered prerequisites, so nothing stops installcheck's own prerequisite
 # chain from running before install. An explicit edge here, same as
 # check-stale-expected's, is the only ordering guarantee Make actually gives.
+#
+# Gated behind PGXNTOOL_ENABLE_FS_INSTALL (see its definition above): when
+# disabled, `installcheck` must run against whatever is already installed
+# (e.g. via pg_tle) instead of forcing a filesystem install first.
+ifeq ($(PGXNTOOL_ENABLE_FS_INSTALL),yes)
 installcheck: install
+endif
 
 #
 # TEST SUPPORT
@@ -371,7 +436,13 @@ endif
 ifeq ($(PGXNTOOL_ENABLE_TEST_BUILD),yes)
 TEST_DEPS += test-build
 endif
-TEST_DEPS += install installcheck
+# install is gated behind PGXNTOOL_ENABLE_FS_INSTALL (see its definition
+# above): when disabled, `test`/`verify-results` run against whatever is
+# already installed instead of forcing a filesystem install first.
+ifeq ($(PGXNTOOL_ENABLE_FS_INSTALL),yes)
+TEST_DEPS += install
+endif
+TEST_DEPS += installcheck
 test: $(TEST_DEPS)
 	@if [ -r $(TESTOUT)/regression.diffs ]; then cat $(TESTOUT)/regression.diffs; exit 1; fi
 
@@ -500,7 +571,17 @@ ifeq ($(PGXNTOOL_ENABLE_TEST_BUILD),yes)
 TEST_BUILD_SQL_DIR = $(TESTDIR)/build/sql
 TEST_BUILD_REGRESS = $(sort $(notdir $(basename $(TEST_BUILD_SQL_FILES))))
 .PHONY: test-build
+# Gated behind PGXNTOOL_ENABLE_FS_INSTALL (see its definition above): without
+# this, test-build would force a real filesystem install even when the rest
+# of test/installcheck was told not to, defeating the point of disabling it.
+# The prerequisite is added via its own separate rule line (no recipe of its
+# own) rather than wrapping the ifeq/endif around the recipe-bearing line
+# below -- a recipe must immediately follow its own target line, and an
+# intervening `endif` would orphan it when the condition is false.
+ifeq ($(PGXNTOOL_ENABLE_FS_INSTALL),yes)
 test-build: install
+endif
+test-build:
 	@$(PGXNTOOL_DIR)/run-test-build.sh $(TESTDIR)
 	$(MAKE) -C . REGRESS="$(TEST_BUILD_REGRESS)" REGRESS_OPTS="--inputdir=$(TESTDIR)/build --outputdir=$(TESTDIR)/build" installcheck
 	@if [ -r $(TESTDIR)/build/regression.diffs ]; then \
@@ -679,11 +760,16 @@ endif
 # the META handling stuff is it's own makefile.
 #
 .PHONY: pgtap
+# Gated behind PGXNTOOL_ENABLE_PGXN_INSTALL (see its definition above): when
+# disabled, pgtap is a no-op and pg_regress runs assuming pgtap is already
+# available some other way.
+ifeq ($(PGXNTOOL_ENABLE_PGXN_INSTALL),yes)
 installcheck: pgtap
 pgtap: $(DESTDIR)$(datadir)/extension/pgtap.control
 
 $(DESTDIR)$(datadir)/extension/pgtap.control:
 	pgxn install pgtap --sudo
+endif
 
 endif # fndef PGXNTOOL_NO_PGXS_INCLUDE
 


### PR DESCRIPTION
## Summary
- `test`/`verify-results`/`installcheck`/`test-build` always filesystem-installed the extension via PGXS's `install`, with no way to disable it -- breaking "existing mode"/pg_tle-style testing, where the extension under test is deployed some other way and a filesystem install as a side effect defeats the point of the test. `PGXNTOOL_ENABLE_FS_INSTALL` (default `yes`) now gates `install` out of all four.
- `installcheck` also unconditionally auto-installed the pgtap dependency via `pgxn install pgtap --sudo`. `PGXNTOOL_ENABLE_PGXN_INSTALL` independently gates that, defaulting to follow `PGXNTOOL_ENABLE_FS_INSTALL` but overridable on its own.
- Documented both variables in README.asc; HISTORY.asc entry added.

Fixes #55.
Fixes #90.

Companion pgxntool-test PR: Postgres-Extensions/pgxntool-test#70

## Test plan
- [x] `test/standard/make-test.bats` (35/35) and full `test-all` suite (257/257) pass in pgxntool-test against this branch