### PR TITLE
Rename internal-only variables to the _PGXNTOOL_ shape

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,22 @@
+STABLE
+------
+== Rename internal-only variables to the `_PGXNTOOL_` shape
+Several variables that are pure internal plumbing -- never designed as user
+override points -- were named with a bare `PGXNTOOL_` prefix, which reads
+like a supported override point by name alone. Renamed to signal "internal,
+not part of the user-facing surface", matching the existing
+`_CHECK_STALE_EXPECTED_SCRIPT` precedent (itself renamed here too, for the
+same `_PGXNTOOL_` consistency): `PGXNTOOL_BASE_MK_INCLUDED` ->
+`_PGXNTOOL_BASE_MK_INCLUDED`, `PGXNTOOL_CONTROL_FILES` ->
+`_PGXNTOOL_CONTROL_FILES`, `PGXNTOOL_EXTENSIONS` -> `_PGXNTOOL_EXTENSIONS`,
+`PGXNTOOL_INSTALL_SCHEDULE` -> `_PGXNTOOL_INSTALL_SCHEDULE`, and
+`_CHECK_STALE_EXPECTED_SCRIPT` -> `_PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT`.
+None of these are documented anywhere as override points, but if you happened
+to reference one directly (unsupported, but possible), update to the new
+name.
+
+Issues fixed in this release: #87
+
 2.3.0
 -----
 == Rename `PGTLE_VERSION` to `PGXNTOOL_PGTLE_VERSION`

--- a/base.mk
+++ b/base.mk
@@ -4,8 +4,8 @@
 # this, every target in the file gets redefined, producing
 # overriding-recipe/ignoring-old-recipe warnings. A second inclusion is a
 # harmless no-op.
-ifndef PGXNTOOL_BASE_MK_INCLUDED
-PGXNTOOL_BASE_MK_INCLUDED := 1
+ifndef _PGXNTOOL_BASE_MK_INCLUDED
+_PGXNTOOL_BASE_MK_INCLUDED := 1
 
 PGXNTOOL_DIR := pgxntool
 
@@ -39,10 +39,10 @@ meta.mk: META.json Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOOL_DIR)/meta.mk.sh
 # These can differ, and PostgreSQL cares about the control file version.
 #
 # Find all control files first (needed for dependencies)
-PGXNTOOL_CONTROL_FILES := $(wildcard *.control)
+_PGXNTOOL_CONTROL_FILES := $(wildcard *.control)
 PGXNTOOL_distclean += control.mk
-control.mk: $(PGXNTOOL_CONTROL_FILES) Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOOL_DIR)/control.mk.sh
-	@$(PGXNTOOL_DIR)/control.mk.sh $(PGXNTOOL_CONTROL_FILES) >$@
+control.mk: $(_PGXNTOOL_CONTROL_FILES) Makefile $(PGXNTOOL_DIR)/base.mk $(PGXNTOOL_DIR)/control.mk.sh
+	@$(PGXNTOOL_DIR)/control.mk.sh $(_PGXNTOOL_CONTROL_FILES) >$@
 
 -include control.mk
 
@@ -218,7 +218,7 @@ PGXNTOOL_VERIFY_RESULTS_MODE ?= pgtap
 #   - Passed through to check-stale-expected.sh; see that script for the
 #     distinct error message/exit code this sub-check uses
 #
-# Variable: _CHECK_STALE_EXPECTED_SCRIPT (internal shim, not user-facing)
+# Variable: _PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT (internal shim, not user-facing)
 #   - Path to the script the check-stale-expected target invokes
 #   - Default: $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
 #
@@ -237,7 +237,7 @@ else
   PGXNTOOL_CHECK_EXPECTED_FILE_TYPES = yes
 endif
 
-_CHECK_STALE_EXPECTED_SCRIPT ?= $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
+_PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT ?= $(PGXNTOOL_DIR)/test/bin/check-stale-expected.sh
 
 # Generate unique database name for tests to prevent conflicts across projects
 # Uses project name + first 5 chars of md5 hash of current directory
@@ -288,21 +288,21 @@ endif
 # install files in their original location without copying.
 #
 ifeq ($(PGXNTOOL_ENABLE_TEST_INSTALL),yes)
-PGXNTOOL_INSTALL_SCHEDULE = $(TESTDIR)/install/schedule
-EXTRA_CLEAN += $(PGXNTOOL_INSTALL_SCHEDULE)
+_PGXNTOOL_INSTALL_SCHEDULE = $(TESTDIR)/install/schedule
+EXTRA_CLEAN += $(_PGXNTOOL_INSTALL_SCHEDULE)
 
 # Add install schedule; REGRESS stays as-is (regular tests run after schedule)
-REGRESS_OPTS += --schedule=$(PGXNTOOL_INSTALL_SCHEDULE)
+REGRESS_OPTS += --schedule=$(_PGXNTOOL_INSTALL_SCHEDULE)
 
 # Always regenerate schedule file to catch added/removed files
-.PHONY: $(PGXNTOOL_INSTALL_SCHEDULE)
-$(PGXNTOOL_INSTALL_SCHEDULE):
+.PHONY: $(_PGXNTOOL_INSTALL_SCHEDULE)
+$(_PGXNTOOL_INSTALL_SCHEDULE):
 	@echo "# Auto-generated - DO NOT EDIT" > $@
 	@for f in $(notdir $(basename $(TEST_INSTALL_SQL_FILES))); do \
 		echo "test: ../install/$$f" >> $@; \
 	done
 
-installcheck: $(PGXNTOOL_INSTALL_SCHEDULE)
+installcheck: $(_PGXNTOOL_INSTALL_SCHEDULE)
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
@@ -357,7 +357,7 @@ TEST_DEPS = testdeps
 ifeq ($(PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED),yes)
 .PHONY: check-stale-expected
 check-stale-expected: installcheck
-	@$(_CHECK_STALE_EXPECTED_SCRIPT) $(TESTDIR) $(PGXNTOOL_CHECK_EXPECTED_FILE_TYPES)
+	@$(_PGXNTOOL_CHECK_STALE_EXPECTED_SCRIPT) $(TESTDIR) $(PGXNTOOL_CHECK_EXPECTED_FILE_TYPES)
 TEST_DEPS += check-stale-expected
 endif
 
@@ -433,8 +433,8 @@ testdeps: pgtap
 # pg_tle support - Generate pg_tle registration SQL
 #
 
-# PGXNTOOL_CONTROL_FILES is defined above (for control.mk dependencies)
-PGXNTOOL_EXTENSIONS = $(basename $(PGXNTOOL_CONTROL_FILES))
+# _PGXNTOOL_CONTROL_FILES is defined above (for control.mk dependencies)
+_PGXNTOOL_EXTENSIONS = $(basename $(_PGXNTOOL_CONTROL_FILES))
 
 # Main target
 # Depend on 'all' to ensure versioned SQL files are generated first
@@ -447,8 +447,8 @@ PGXNTOOL_EXTENSIONS = $(basename $(PGXNTOOL_CONTROL_FILES))
 # "which pg_tle to test against" env var (see issue #78) -- that collided
 # with this variable silently instead of erroring.
 .PHONY: pgtle
-pgtle: all control.mk $(PGXNTOOL_CONTROL_FILES)
-	@$(foreach ext,$(PGXNTOOL_EXTENSIONS),\
+pgtle: all control.mk $(_PGXNTOOL_CONTROL_FILES)
+	@$(foreach ext,$(_PGXNTOOL_EXTENSIONS),\
 		$(PGXNTOOL_DIR)/pgtle.sh --extension $(ext) $(if $(PGXNTOOL_PGTLE_VERSION),--pgtle-version $(PGXNTOOL_PGTLE_VERSION));)
 
 #
@@ -687,4 +687,4 @@ $(DESTDIR)$(datadir)/extension/pgtap.control:
 
 endif # fndef PGXNTOOL_NO_PGXS_INCLUDE
 
-endif # ifndef PGXNTOOL_BASE_MK_INCLUDED
+endif # ifndef _PGXNTOOL_BASE_MK_INCLUDED


### PR DESCRIPTION
## Summary
- Renamed 5 pure-internal-plumbing Make variables from a bare `PGXNTOOL_` prefix (which reads like a supported override point) to `_PGXNTOOL_...`: `PGXNTOOL_BASE_MK_INCLUDED`, `PGXNTOOL_CONTROL_FILES`, `PGXNTOOL_EXTENSIONS`, `PGXNTOOL_INSTALL_SCHEDULE`, and `_CHECK_STALE_EXPECTED_SCRIPT` (renamed too, for `_PGXNTOOL_` consistency).
- `PGXNTOOL_DIR` deliberately left as-is: present since Release 0.1 (2016), referenced across `base.mk` plus 4 shell scripts — highest-risk name in the framework to touch, out of scope here.
- HISTORY.asc updated (new STABLE section, `Issues fixed in this release: #87`).

Fixes #87.

Paired with Postgres-Extensions/pgxntool-test#72 for the corresponding test/doc updates.

## Test plan
- [x] Full pgxntool-test suite passes against this branch (248/248, 0 skips, 0 failures)