### PR TITLE
Add `make print-pgtle` target for combined pg_tle install files

### DIFF
--- a/HISTORY.asc
+++ b/HISTORY.asc
@@ -1,3 +1,19 @@
+STABLE
+------
+== Add `print-pgtle` target for combined multi-extension pg_tle files
+`make print-pgtle` prints the generated pg_tle registration SQL for each
+extension to stdout, selecting the version directory from the new
+`PGXNTOOL_PGTLE_TARGET_VERSION` variable (an actual pg_tle version, e.g.
+`1.5.2`) or, if unset, the installed pg_tle version. This lets a consumer
+build a combined multi-extension install file (e.g.
+`$(MAKE) -C ../deps/cat_tools print-pgtle >> pgtle-all.sql`) without needing
+to know the extension name or which `pg_tle/` version-range directory
+applies. When invoking it recursively for stdout capture, pass
+`--no-print-directory` -- otherwise GNU Make's own `Entering
+directory`/`Leaving directory` announcements pollute the captured output.
+
+Issues fixed in this release: #21
+
 2.3.0
 -----
 == Rename `PGTLE_VERSION` to `PGXNTOOL_PGTLE_VERSION`

--- a/README.asc
+++ b/README.asc
@@ -346,6 +346,25 @@ After running `make run-pgtle`, you can create your extension in the database:
 CREATE EXTENSION "your-extension-name";
 ----
 
+=== print-pgtle
+Prints the generated pg_tle registration SQL to stdout instead of running it, for consumers building a combined multi-extension install file. This target:
+- Depends on `pgtle`, so the SQL files are (re)generated first
+- Selects the version directory from `PGXNTOOL_PGTLE_TARGET_VERSION` if set (an actual pg_tle version like `1.5.2`, not a range like `PGXNTOOL_PGTLE_VERSION` uses), otherwise from the installed pg_tle version (queried the same way `run-pgtle` does)
+- Errors if neither is available (no `PGXNTOOL_PGTLE_TARGET_VERSION` and pg_tle isn't installed)
+- When invoked recursively (`$(MAKE) -C ... print-pgtle`) for stdout capture, pass `--no-print-directory` -- see warning below
+
+----
+make print-pgtle
+make print-pgtle PGXNTOOL_PGTLE_TARGET_VERSION=1.5.2
+----
+
+A dependency's registration SQL can be pulled into a combined file without the caller needing to know its extension name or which `pg_tle/` version-range directory applies:
+----
+$(MAKE) --no-print-directory -C ../deps/cat_tools print-pgtle >> pgtle-all.sql
+----
+
+WARNING: Always pass `--no-print-directory` when invoking `print-pgtle` recursively from another Makefile's recipe (as above). GNU Make auto-prints `Entering directory`/`Leaving directory` announcements to stdout for recursive invocations, which silently corrupts a redirected combined SQL file with garbage lines. `--no-print-directory` suppresses them.
+
 == Version-Specific SQL Files
 
 PGXNtool automatically generates version-specific SQL files from your base SQL file. These files follow the pattern `sql/{extension}--{version}.sql` and are used by PostgreSQL's extension system to install specific versions of your extension.
@@ -554,7 +573,7 @@ PGXNtool appends *all* files found in all `$(DOC_DIRS)` to `DOCS`.
 [[_pg_tle_Support]]
 pgxntool can generate link:https://github.com/aws/pg_tle[pg_tle (Trusted Language Extensions)] registration SQL for deploying PostgreSQL extensions in managed environments like AWS RDS and Aurora where filesystem access is not available.
 
-For make targets, see: <<_pgtle>>, <<_check_pgtle>>, <<_run_pgtle>>.
+For make targets, see: <<_pgtle>>, <<_check_pgtle>>, <<_run_pgtle>>, <<_print_pgtle>>.
 
 === What is pg_tle?
 
@@ -685,6 +704,10 @@ Default: auto-detected, the first of `asciidoctor` or `asciidoc` found on `PATH`
 === PGXNTOOL_PGTLE_VERSION
 
 Default: unset (generates every known pg_tle version range). Set on the command line to limit `make pgtle` to the single version range this value falls into. Not named `PGTLE_VERSION`: make auto-imports same-named environment variables, and that name collided silently with CI jobs that set a `PGTLE_VERSION` env var for an unrelated purpose (which pg_tle to test against). See <<_pgtle>>.
+
+=== PGXNTOOL_PGTLE_TARGET_VERSION
+
+Default: unset (falls back to the installed pg_tle version). Set on the command line to an actual pg_tle version (e.g. `1.5.2`, not a range) to select which `pg_tle/` directory `make print-pgtle` reads from, without needing a database connection. Distinct from `PGXNTOOL_PGTLE_VERSION`, which holds a range and controls generation rather than selection. See <<_print_pgtle>>.
 
 === PG_CONFIG
 

--- a/README.html
+++ b/README.html
@@ -464,6 +464,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_pgtle">4.14. pgtle</a></li>
 <li><a href="#_check_pgtle">4.15. check-pgtle</a></li>
 <li><a href="#_run_pgtle">4.16. run-pgtle</a></li>
+<li><a href="#_print_pgtle">4.17. print-pgtle</a></li>
 </ul>
 </li>
 <li><a href="#_version_specific_sql_files">5. Version-Specific SQL Files</a>
@@ -501,16 +502,17 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_pgxn_remote">8.1. PGXN_REMOTE</a></li>
 <li><a href="#_asciidoc">8.2. ASCIIDOC</a></li>
 <li><a href="#_pgxntool_pgtle_version">8.3. PGXNTOOL_PGTLE_VERSION</a></li>
-<li><a href="#_pg_config">8.4. PG_CONFIG</a></li>
-<li><a href="#_testdir">8.5. TESTDIR</a></li>
-<li><a href="#_testout">8.6. TESTOUT</a></li>
-<li><a href="#_pgxntool_verify_results_mode">8.7. PGXNTOOL_VERIFY_RESULTS_MODE</a></li>
-<li><a href="#_pgxntool_enable_test_build">8.8. PGXNTOOL_ENABLE_TEST_BUILD *</a></li>
-<li><a href="#_pgxntool_enable_test_install">8.9. PGXNTOOL_ENABLE_TEST_INSTALL *</a></li>
-<li><a href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
-<li><a href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
-<li><a href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
-<li><a href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
+<li><a href="#_pgxntool_pgtle_target_version">8.4. PGXNTOOL_PGTLE_TARGET_VERSION</a></li>
+<li><a href="#_pg_config">8.5. PG_CONFIG</a></li>
+<li><a href="#_testdir">8.6. TESTDIR</a></li>
+<li><a href="#_testout">8.7. TESTOUT</a></li>
+<li><a href="#_pgxntool_verify_results_mode">8.8. PGXNTOOL_VERIFY_RESULTS_MODE</a></li>
+<li><a href="#_pgxntool_enable_test_build">8.9. PGXNTOOL_ENABLE_TEST_BUILD *</a></li>
+<li><a href="#_pgxntool_enable_test_install">8.10. PGXNTOOL_ENABLE_TEST_INSTALL *</a></li>
+<li><a href="#_pgxntool_enable_verify_results">8.11. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></li>
+<li><a href="#_pgxntool_enable_check_stale_expected">8.12. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></li>
+<li><a href="#_pgxntool_check_expected_file_types">8.13. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></li>
+<li><a href="#_pgxntool_no_pgxs_include">8.14. PGXNTOOL_NO_PGXS_INCLUDE</a></li>
 </ul>
 </li>
 <li><a href="#_copyright">9. Copyright</a></li>
@@ -624,6 +626,18 @@ all the targets normally provided by Postgres <a href="http://www.postgresql.org
 </td>
 <td class="content">
 <code>test</code> intentionally does <strong>not</strong> depend on <code>clean</code> — that caused problems with incremental/watch-based builds. If your tests need a clean build to pass, that&#8217;s a sign of a missing dependency elsewhere rather than something to fix by adding <code>clean</code> back.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<code>test</code> exits non-zero (after printing <code>regression.diffs</code>) if any test fails. Previously it always exited 0 regardless of test results, silently masking failures from CI and other automation that relies on the exit code.
 </td>
 </tr>
 </table>
@@ -1071,7 +1085,7 @@ If your project has a <code>.gitattributes</code> file, <code>make dist</code>/<
 <div class="sect2">
 <h3 id="_pgxntool_sync"><a class="anchor" href="#_pgxntool_sync"></a><a class="link" href="#_pgxntool_sync">4.9. pgxntool-sync</a></h3>
 <div class="paragraph">
-<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code> and then reconcile the files <code>setup.sh</code> copied into your project (<code>.gitignore</code>, <code>test/deps.sql</code>) with a 3-way merge.</p>
+<p>This rule will pull down the latest released version of PGXNtool via <code>git subtree pull</code> and then reconcile the files <code>setup.sh</code> copied into your project (<code>.gitignore</code>, <code>test/deps.sql</code>) with a 3-way merge (it also verifies the <code>test/pgxntool</code> symlink, recreating it if missing).</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -1258,6 +1272,42 @@ The <code>pgtle</code> target is a dependency, so <code>make run-pgtle</code> wi
 <div class="content">
 <pre>CREATE EXTENSION "your-extension-name";</pre>
 </div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_print_pgtle"><a class="anchor" href="#_print_pgtle"></a><a class="link" href="#_print_pgtle">4.17. print-pgtle</a></h3>
+<div class="paragraph">
+<p>Prints the generated pg_tle registration SQL to stdout instead of running it, for consumers building a combined multi-extension install file. This target:
+- Depends on <code>pgtle</code>, so the SQL files are (re)generated first
+- Selects the version directory from <code>PGXNTOOL_PGTLE_TARGET_VERSION</code> if set (an actual pg_tle version like <code>1.5.2</code>, not a range like <code>PGXNTOOL_PGTLE_VERSION</code> uses), otherwise from the installed pg_tle version (queried the same way <code>run-pgtle</code> does)
+- Errors if neither is available (no <code>PGXNTOOL_PGTLE_TARGET_VERSION</code> and pg_tle isn&#8217;t installed)
+- When invoked recursively (<code>$(MAKE) -C &#8230;&#8203; print-pgtle</code>) for stdout capture, pass <code>--no-print-directory</code>&#8201;&#8212;&#8201;see warning below</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>make print-pgtle
+make print-pgtle PGXNTOOL_PGTLE_TARGET_VERSION=1.5.2</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>A dependency&#8217;s registration SQL can be pulled into a combined file without the caller needing to know its extension name or which <code>pg_tle/</code> version-range directory applies:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$(MAKE) --no-print-directory -C ../deps/cat_tools print-pgtle &gt;&gt; pgtle-all.sql</pre>
+</div>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Warning</div>
+</td>
+<td class="content">
+Always pass <code>--no-print-directory</code> when invoking <code>print-pgtle</code> recursively from another Makefile&#8217;s recipe (as above). GNU Make auto-prints <code>Entering directory</code>/<code>Leaving directory</code> announcements to stdout for recursive invocations, which silently corrupts a redirected combined SQL file with garbage lines. <code>--no-print-directory</code> suppresses them.
+</td>
+</tr>
+</table>
 </div>
 </div>
 </div>
@@ -1649,7 +1699,7 @@ Because of this, <code>base.mk</code> will forcibly define it to be NULL if it&#
 <p>pgxntool can generate <a href="https://github.com/aws/pg_tle">pg_tle (Trusted Language Extensions)</a> registration SQL for deploying PostgreSQL extensions in managed environments like AWS RDS and Aurora where filesystem access is not available.</p>
 </div>
 <div class="paragraph">
-<p>For make targets, see: <a href="#_pgtle">pgtle</a>, <a href="#_check_pgtle">check-pgtle</a>, <a href="#_run_pgtle">run-pgtle</a>.</p>
+<p>For make targets, see: <a href="#_pgtle">pgtle</a>, <a href="#_check_pgtle">check-pgtle</a>, <a href="#_run_pgtle">run-pgtle</a>, <a href="#_print_pgtle">print-pgtle</a>.</p>
 </div>
 <div class="sect2">
 <h3 id="_what_is_pg_tle"><a class="anchor" href="#_what_is_pg_tle"></a><a class="link" href="#_what_is_pg_tle">7.1. What is pg_tle?</a></h3>
@@ -1893,61 +1943,67 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pg_config"><a class="anchor" href="#_pg_config"></a><a class="link" href="#_pg_config">8.4. PG_CONFIG</a></h3>
+<h3 id="_pgxntool_pgtle_target_version"><a class="anchor" href="#_pgxntool_pgtle_target_version"></a><a class="link" href="#_pgxntool_pgtle_target_version">8.4. PGXNTOOL_PGTLE_TARGET_VERSION</a></h3>
+<div class="paragraph">
+<p>Default: unset (falls back to the installed pg_tle version). Set on the command line to an actual pg_tle version (e.g. <code>1.5.2</code>, not a range) to select which <code>pg_tle/</code> directory <code>make print-pgtle</code> reads from, without needing a database connection. Distinct from <code>PGXNTOOL_PGTLE_VERSION</code>, which holds a range and controls generation rather than selection. See <a href="#_print_pgtle">print-pgtle</a>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_pg_config"><a class="anchor" href="#_pg_config"></a><a class="link" href="#_pg_config">8.5. PG_CONFIG</a></h3>
 <div class="paragraph">
 <p>Default: <code>pg_config</code>. Path to the <code>pg_config</code> binary used to detect the PostgreSQL version and locate PGXS. Override when the right <code>pg_config</code> isn&#8217;t the one on <code>PATH</code>, such as when testing against a specific PostgreSQL install.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_testdir"><a class="anchor" href="#_testdir"></a><a class="link" href="#_testdir">8.5. TESTDIR</a></h3>
+<h3 id="_testdir"><a class="anchor" href="#_testdir"></a><a class="link" href="#_testdir">8.6. TESTDIR</a></h3>
 <div class="paragraph">
 <p>Default: <code>test</code>. Root directory for test input files: <code>$(TESTDIR)/sql/</code>, <code>$(TESTDIR)/expected/</code>, <code>$(TESTDIR)/build/</code>, <code>$(TESTDIR)/install/</code>. Overriding this on its own is unusual; it mainly exists so <code>TESTOUT</code> has a sensible default.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_testout"><a class="anchor" href="#_testout"></a><a class="link" href="#_testout">8.6. TESTOUT</a></h3>
+<h3 id="_testout"><a class="anchor" href="#_testout"></a><a class="link" href="#_testout">8.7. TESTOUT</a></h3>
 <div class="paragraph">
 <p>Default: <code>$(TESTDIR)</code>. Directory <code>pg_regress</code> writes actual test output to&#8201;&#8212;&#8201;<code>$(TESTOUT)/results/</code>, <code>$(TESTOUT)/regression.diffs</code>, etc.&#8201;&#8212;&#8201;via <code>--outputdir</code> in <code>REGRESS_OPTS</code>. Kept separate from <code>TESTDIR</code> so generated output can be pointed somewhere other than the directory holding your checked-in <code>sql</code>/<code>expected</code> files, if you want that separation.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_verify_results_mode"><a class="anchor" href="#_pgxntool_verify_results_mode"></a><a class="link" href="#_pgxntool_verify_results_mode">8.7. PGXNTOOL_VERIFY_RESULTS_MODE</a></h3>
+<h3 id="_pgxntool_verify_results_mode"><a class="anchor" href="#_pgxntool_verify_results_mode"></a><a class="link" href="#_pgxntool_verify_results_mode">8.8. PGXNTOOL_VERIFY_RESULTS_MODE</a></h3>
 <div class="paragraph">
 <p>Default: <code>pgtap</code>. Controls how the <a href="#_verify_results_safeguard">verify-results safeguard</a> decides whether tests are failing.</p>
 </div>
 <div class="sect3">
-<h4 id="_pgtap"><a class="anchor" href="#_pgtap"></a><a class="link" href="#_pgtap">8.7.1. pgtap</a></h4>
+<h4 id="_pgtap"><a class="anchor" href="#_pgtap"></a><a class="link" href="#_pgtap">8.8.1. pgtap</a></h4>
 <div class="paragraph">
 <p>Scans <code>test/results/*.out</code> for pgTap <code>not ok</code> lines and plan mismatches, falling back to checking for <code>regression.diffs</code> too. Use this mode when your test suite uses pgTap.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_diffs"><a class="anchor" href="#_diffs"></a><a class="link" href="#_diffs">8.7.2. diffs</a></h4>
+<h4 id="_diffs"><a class="anchor" href="#_diffs"></a><a class="link" href="#_diffs">8.8.2. diffs</a></h4>
 <div class="paragraph">
 <p>Checks only for <code>regression.diffs</code>, matching classic pg_regress behavior. Use this mode when your tests use plain SQL expected-output comparison only.</p>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_test_build"><a class="anchor" href="#_pgxntool_enable_test_build"></a><a class="link" href="#_pgxntool_enable_test_build">8.8. PGXNTOOL_ENABLE_TEST_BUILD *</a></h3>
+<h3 id="_pgxntool_enable_test_build"><a class="anchor" href="#_pgxntool_enable_test_build"></a><a class="link" href="#_pgxntool_enable_test_build">8.9. PGXNTOOL_ENABLE_TEST_BUILD *</a></h3>
 <div class="paragraph">
 <p>Default: auto-detected&#8201;&#8212;&#8201;<code>yes</code> if <code>test/build/*.sql</code> files exist, <code>no</code> otherwise. Enables or disables the <a href="#_test_build">test-build</a> pre-flight SQL check. Set explicitly to <code>yes</code> if you want an error when <code>test/build/</code> unexpectedly has no SQL files (catches accidental deletion of its contents), or to <code>no</code> to disable the check even when files are present.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_test_install"><a class="anchor" href="#_pgxntool_enable_test_install"></a><a class="link" href="#_pgxntool_enable_test_install">8.9. PGXNTOOL_ENABLE_TEST_INSTALL *</a></h3>
+<h3 id="_pgxntool_enable_test_install"><a class="anchor" href="#_pgxntool_enable_test_install"></a><a class="link" href="#_pgxntool_enable_test_install">8.10. PGXNTOOL_ENABLE_TEST_INSTALL *</a></h3>
 <div class="paragraph">
 <p>Default: auto-detected&#8201;&#8212;&#8201;<code>yes</code> if <code>test/install/*.sql</code> files exist, <code>no</code> otherwise. Enables or disables the <a href="#_testinstall">test/install</a> schedule-based setup feature. Same explicit-override semantics as <code>PGXNTOOL_ENABLE_TEST_BUILD</code>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.10. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
+<h3 id="_pgxntool_enable_verify_results"><a class="anchor" href="#_pgxntool_enable_verify_results"></a><a class="link" href="#_pgxntool_enable_verify_results">8.11. PGXNTOOL_ENABLE_VERIFY_RESULTS *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the <a href="#_verify_results_safeguard">verify-results safeguard</a> that blocks <code>make results</code> when tests are failing. Setting it to empty on the command line (<code>make PGXNTOOL_ENABLE_VERIFY_RESULTS= results</code>) also disables it.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.11. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
+<h3 id="_pgxntool_enable_check_stale_expected"><a class="anchor" href="#_pgxntool_enable_check_stale_expected"></a><a class="link" href="#_pgxntool_enable_check_stale_expected">8.12. PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Enables or disables the check-stale-expected safeguard, which fails <code>make test</code> if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains a <code>.out</code> file with no corresponding <code>.sql</code> file&#8201;&#8212;&#8201;catching a stale file left behind after a test was renamed or removed. Set to <code>no</code> to make the check a complete no-op (it&#8217;s dropped from <code>TEST_DEPS</code> entirely).</p>
 </div>
@@ -1956,13 +2012,13 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.12. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
+<h3 id="_pgxntool_check_expected_file_types"><a class="anchor" href="#_pgxntool_check_expected_file_types"></a><a class="link" href="#_pgxntool_check_expected_file_types">8.13. PGXNTOOL_CHECK_EXPECTED_FILE_TYPES *</a></h3>
 <div class="paragraph">
 <p>Default: <code>yes</code>. Sub-check of check-stale-expected, independent of <code>PGXNTOOL_ENABLE_CHECK_STALE_EXPECTED</code>: fails (with a distinct error message and exit code from the orphaned-<code>.out</code> check) if <code>test/expected/</code> (or <code>test/build/expected/</code>) contains any file that isn&#8217;t <code>*.out</code>. Set to <code>no</code> to disable just this sub-check while leaving the orphaned-<code>.out</code> check active.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.13. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
+<h3 id="_pgxntool_no_pgxs_include"><a class="anchor" href="#_pgxntool_no_pgxs_include"></a><a class="link" href="#_pgxntool_no_pgxs_include">8.14. PGXNTOOL_NO_PGXS_INCLUDE</a></h3>
 <div class="paragraph">
 <p>Default: unset (PGXS is included normally). Skips including PGXS (<code>$(PGXS)</code>) entirely. This is only for advanced scenarios where you need to manage the PGXS include yourself; most projects should never set this.</p>
 </div>
@@ -1983,7 +2039,7 @@ Variables marked with <code>*</code> must be set to exactly <code>yes</code> or 
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-31 16:13:06 -0500
+Last updated 2026-08-01 17:56:29 -0500
 </div>
 </div>
 </body>

--- a/base.mk
+++ b/base.mk
@@ -479,6 +479,42 @@ check-pgtle:
 run-pgtle: pgtle
 	@$(PGXNTOOL_DIR)/pgtle.sh --run
 
+# Print generated pg_tle registration SQL to stdout, for consumers building
+# a combined multi-extension install file, e.g.:
+#   $(MAKE) --no-print-directory -C ../deps/cat_tools print-pgtle >> pgtle-all.sql
+# --no-print-directory is required: GNU Make auto-prints "Entering
+# directory"/"Leaving directory" to stdout for recursive invocations like
+# this one, which would otherwise corrupt the redirected file.
+# Depends on 'pgtle' so the SQL files are (re)generated first.
+# Selects the directory via PGXNTOOL_PGTLE_TARGET_VERSION if set (an actual
+# pg_tle version like 1.5.2, not a range), otherwise via the installed
+# version (pgtle.sh --get-version). Deliberately not named PGTLE_VERSION or
+# reusing PGXNTOOL_PGTLE_VERSION: a CI job's PGTLE_VERSION env var means
+# "which pg_tle to test against," a concept that can legitimately diverge
+# from "which version this printed artifact should target" -- collapsing
+# them would silently produce a plausible-but-wrong artifact on divergence.
+# PGXNTOOL_PGTLE_VERSION itself holds a range (e.g. 1.5.0+), not an exact
+# version, so it can't be reused here either.
+.PHONY: print-pgtle
+print-pgtle: pgtle
+	@version="$(PGXNTOOL_PGTLE_TARGET_VERSION)"; \
+	if [ -z "$$version" ]; then \
+		version=$$($(PGXNTOOL_DIR)/pgtle.sh --get-version 2>/dev/null); \
+		if [ -z "$$version" ]; then \
+			echo "ERROR: pg_tle version not specified and pg_tle is not installed" >&2; \
+			echo "       Set PGXNTOOL_PGTLE_TARGET_VERSION=X.Y.Z, or run 'CREATE EXTENSION pg_tle;' first" >&2; \
+			exit 1; \
+		fi; \
+	fi; \
+	pgtle_dir=$$($(PGXNTOOL_DIR)/pgtle.sh --get-dir "$$version") || exit 1; \
+	$(foreach ext,$(PGXNTOOL_EXTENSIONS),\
+		f="$$pgtle_dir/$(ext).sql"; \
+		if [ ! -f "$$f" ]; then \
+			echo "ERROR: $$f does not exist (run 'make pgtle' first)" >&2; \
+			exit 1; \
+		fi; \
+		cat "$$f";)
+
 # These targets ensure all the relevant directories exist
 $(TESTDIR)/sql $(TESTDIR)/expected/ $(TESTOUT)/results/:
 	@mkdir -p $@


### PR DESCRIPTION
## Summary

Adds a `make print-pgtle` target that prints the generated pg_tle registration SQL for each extension to stdout instead of running it, so a consumer can build a combined multi-extension install file:

```
$(MAKE) --no-print-directory -C ../deps/cat_tools print-pgtle >> pgtle-all.sql
```

- Depends on `pgtle` (regenerates SQL first, like `run-pgtle`).
- New `PGXNTOOL_PGTLE_TARGET_VERSION` variable (an actual pg_tle version like `1.5.2`, not a range) selects the directory; falls back to the installed pg_tle version if unset.
- Deliberately not named bare `PGTLE_VERSION` (would reopen the #78 collision) or reusing `PGXNTOOL_PGTLE_VERSION` (that holds a range, a different concept).
- Documents a real footgun found while writing tests: GNU Make auto-prints `Entering directory`/`Leaving directory` to stdout on recursive invocation, corrupting a redirected combined file unless `--no-print-directory` is passed. Called out prominently in README.asc and base.mk.

## Companion PR

pgxntool-test: Postgres-Extensions/pgxntool-test#73

## Test plan

- [x] Full pgxntool-test suite (254/254, 0 failed, 0 skipped) passes with this branch paired against the companion test PR.

Fixes #21.