### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Find paired pgxntool-test PR or check commit-with-no-tests label
         id: check
         # Pinned to an immutable SHA (supply-chain hardening); comment tracks the tag.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           # GITHUB_TOKEN is sufficient for reading public repos. If these repos
           # are ever made private, replace with a PAT stored as a secret with

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -93,7 +93,7 @@ jobs:
         # No `repository:`/`ref:` here on purpose — this checks out the base
         # branch (master), never the fork's PR head. See the SECURITY note
         # above.
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         # Intentionally tracks the major-version tag (not a pinned SHA) so
         # upstream fixes are picked up automatically.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/protect-label.yml
+++ b/.github/workflows/protect-label.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Enforce write-access-only on 'commit-with-no-tests' label
         # Pinned to an immutable SHA: this workflow runs as pull_request_target
         # with write access, so a moved upstream tag must not change what runs.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const actor = context.actor;


### PR DESCRIPTION
Bump actions/checkout and actions/github-script to their latest published major versions to clear the Node.js 20 deprecation warnings they were triggering in CI logs.

- actions/checkout@v4 -> actions/checkout@v7
- actions/checkout@v6 -> actions/checkout@v7
- actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b (v7) -> actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 (v9)