### PR TITLE
Fix claude-code-review.yml trust gate: check PR author, not head repo owner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,11 +27,11 @@ concurrency:
 
 jobs:
   claude-review:
-    # Trusted fork only, and skip drafts (don't spend API/CI on unfinished PRs).
-    # To add more trusted owners, extend the head-owner check.
+    # Trusted author only, and skip drafts (don't spend API/CI on unfinished PRs).
+    # To add more trusted authors, extend the author check.
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.owner.login == 'jnasbyupgrade'
+      github.event.pull_request.user.login == 'jnasbyupgrade'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
The claude-review job's trust gate checked:

```yaml
if: >-
  github.event.pull_request.draft == false &&
  github.event.pull_request.head.repo.owner.login == 'jnasbyupgrade'
```

`head.repo.owner.login` only identifies who owns the fork for **fork-headed**
PRs. For an **upstream-branch-headed** PR (base and head both live in this
repo -- required by `gh stack`, and also just what you get from `gh pr
create` without a fork), `head.repo.owner.login` is always this repo's own
org, never the actual PR author -- so the gate silently skipped review on
every such PR regardless of who opened it. Confirmed via a real case (in a
sibling repo) where claude-review showed conclusion "skipped" on a whole PR
stack that was legitimately the trusted account's own work.

Fix: check the PR author instead:

```yaml
if: >-
  github.event.pull_request.draft == false &&
  github.event.pull_request.user.login == 'jnasbyupgrade'
```

`user.login` can't be spoofed by a third party any more than head repo owner
can, and it's the more direct question for this gate's actual purpose:
trusting the person asking for review, not the repository their branch
happens to live in. Works for both fork-headed and upstream-branch-headed
PRs.